### PR TITLE
feat: batch add rows, trim empty rows, row numbering (#16, #17, #20)

### DIFF
--- a/src/components/Budget/BudgetRow.test.tsx
+++ b/src/components/Budget/BudgetRow.test.tsx
@@ -31,21 +31,27 @@ describe('BudgetRow', () => {
   });
 
   it('renders correctly', () => {
-    render(<BudgetRow item={item} onUpdate={mockUpdate} onDelete={mockDelete} />);
+    render(
+      <BudgetRow item={item} rowNumber={1} onUpdate={mockUpdate} onDelete={mockDelete} />
+    );
     expect(screen.getByLabelText('Item name')).toHaveValue('Rent');
     expect(screen.getByLabelText('Amount')).toHaveValue(1000);
     expect(screen.getByLabelText('Toggle type, currently -')).toBeInTheDocument();
   });
 
   it('toggles type immediately', () => {
-    render(<BudgetRow item={item} onUpdate={mockUpdate} onDelete={mockDelete} />);
+    render(
+      <BudgetRow item={item} rowNumber={1} onUpdate={mockUpdate} onDelete={mockDelete} />
+    );
     const toggleBtn = screen.getByLabelText('Toggle type, currently -');
     fireEvent.click(toggleBtn);
     expect(mockUpdate).toHaveBeenCalledWith('i1', { type: '+' });
   });
 
   it('updates name after debounce', () => {
-    render(<BudgetRow item={item} onUpdate={mockUpdate} onDelete={mockDelete} />);
+    render(
+      <BudgetRow item={item} rowNumber={1} onUpdate={mockUpdate} onDelete={mockDelete} />
+    );
     const input = screen.getByLabelText('Item name');
     fireEvent.change(input, { target: { value: 'New Rent' } });
 
@@ -60,7 +66,9 @@ describe('BudgetRow', () => {
   });
 
   it('updates amount after debounce', () => {
-    render(<BudgetRow item={item} onUpdate={mockUpdate} onDelete={mockDelete} />);
+    render(
+      <BudgetRow item={item} rowNumber={1} onUpdate={mockUpdate} onDelete={mockDelete} />
+    );
     const input = screen.getByLabelText('Amount');
     fireEvent.change(input, { target: { value: '2000' } });
 
@@ -75,7 +83,9 @@ describe('BudgetRow', () => {
   });
 
   it('saves immediately on blur', () => {
-    render(<BudgetRow item={item} onUpdate={mockUpdate} onDelete={mockDelete} />);
+    render(
+      <BudgetRow item={item} rowNumber={1} onUpdate={mockUpdate} onDelete={mockDelete} />
+    );
     const input = screen.getByLabelText('Item name');
     fireEvent.change(input, { target: { value: 'Blur Rent' } });
     fireEvent.blur(input);
@@ -87,7 +97,9 @@ describe('BudgetRow', () => {
   });
 
   it('handles delete with confirmation', () => {
-    render(<BudgetRow item={item} onUpdate={mockUpdate} onDelete={mockDelete} />);
+    render(
+      <BudgetRow item={item} rowNumber={1} onUpdate={mockUpdate} onDelete={mockDelete} />
+    );
     const deleteBtn = screen.getByLabelText('Delete item');
     fireEvent.click(deleteBtn);
 
@@ -97,7 +109,9 @@ describe('BudgetRow', () => {
 
   it('does not delete if confirmation cancelled', () => {
     (window.confirm as unknown as ReturnType<typeof vi.fn>).mockReturnValue(false);
-    render(<BudgetRow item={item} onUpdate={mockUpdate} onDelete={mockDelete} />);
+    render(
+      <BudgetRow item={item} rowNumber={1} onUpdate={mockUpdate} onDelete={mockDelete} />
+    );
     const deleteBtn = screen.getByLabelText('Delete item');
     fireEvent.click(deleteBtn);
 

--- a/src/components/Budget/BudgetRow.tsx
+++ b/src/components/Budget/BudgetRow.tsx
@@ -4,12 +4,19 @@ import type { BudgetItem } from '../../types';
 
 interface BudgetRowProps {
   item: BudgetItem;
+  rowNumber: number;
   onUpdate: (id: string, changes: Partial<BudgetItem>) => void;
   onDelete: (id: string) => void;
   autoFocus?: boolean;
 }
 
-export function BudgetRow({ item, onUpdate, onDelete, autoFocus }: BudgetRowProps) {
+export function BudgetRow({
+  item,
+  rowNumber,
+  onUpdate,
+  onDelete,
+  autoFocus,
+}: BudgetRowProps) {
   // Local state for immediate feedback
   const [name, setName] = useState(item.name);
   const [amount, setAmount] = useState(item.amount === 0 ? '' : item.amount.toString());
@@ -105,6 +112,9 @@ export function BudgetRow({ item, onUpdate, onDelete, autoFocus }: BudgetRowProp
       }`}
       role="row"
     >
+      <div className="text-xs text-text-secondary w-8 text-center flex-shrink-0 font-mono">
+        {rowNumber}
+      </div>
       <div className="flex-grow min-w-0">
         <input
           type="text"

--- a/src/components/Budget/BudgetTable.test.tsx
+++ b/src/components/Budget/BudgetTable.test.tsx
@@ -6,7 +6,8 @@ import type { BudgetItem } from '../../types';
 import { BudgetTable } from './BudgetTable';
 
 describe('BudgetTable', () => {
-  const mockAddItem = vi.fn();
+  const mockAddItems = vi.fn();
+  const mockTrimRows = vi.fn();
   const mockUpdateItem = vi.fn();
   const mockDeleteItem = vi.fn();
 
@@ -37,7 +38,8 @@ describe('BudgetTable', () => {
     render(
       <BudgetTable
         items={undefined}
-        onAddItem={mockAddItem}
+        onAddItems={mockAddItems}
+        onTrimRows={mockTrimRows}
         onUpdateItem={mockUpdateItem}
         onDeleteItem={mockDeleteItem}
       />
@@ -49,7 +51,8 @@ describe('BudgetTable', () => {
     render(
       <BudgetTable
         items={[]}
-        onAddItem={mockAddItem}
+        onAddItems={mockAddItems}
+        onTrimRows={mockTrimRows}
         onUpdateItem={mockUpdateItem}
         onDeleteItem={mockDeleteItem}
       />
@@ -61,7 +64,8 @@ describe('BudgetTable', () => {
     render(
       <BudgetTable
         items={items}
-        onAddItem={mockAddItem}
+        onAddItems={mockAddItems}
+        onTrimRows={mockTrimRows}
         onUpdateItem={mockUpdateItem}
         onDeleteItem={mockDeleteItem}
       />
@@ -78,14 +82,15 @@ describe('BudgetTable', () => {
     render(
       <BudgetTable
         items={[]}
-        onAddItem={mockAddItem}
+        onAddItems={mockAddItems}
+        onTrimRows={mockTrimRows}
         onUpdateItem={mockUpdateItem}
         onDeleteItem={mockDeleteItem}
       />
     );
 
-    fireEvent.click(screen.getByText('Add item'));
-    expect(mockAddItem).toHaveBeenCalled();
+    fireEvent.click(screen.getByText('+ Add rows'));
+    expect(mockAddItems).toHaveBeenCalled();
   });
 
   it('handles negative total', () => {
@@ -105,7 +110,8 @@ describe('BudgetTable', () => {
     render(
       <BudgetTable
         items={negativeItems}
-        onAddItem={mockAddItem}
+        onAddItems={mockAddItems}
+        onTrimRows={mockTrimRows}
         onUpdateItem={mockUpdateItem}
         onDeleteItem={mockDeleteItem}
       />

--- a/src/components/Budget/WalletDetailPage.tsx
+++ b/src/components/Budget/WalletDetailPage.tsx
@@ -8,19 +8,15 @@ export function WalletDetailPage(): JSX.Element {
   const { id } = useParams<{ id: string }>();
   const walletId = id ?? '';
 
-  const { items, addItem, updateItem, deleteItem, restoreItem } =
+  const { items, addItems, trimEmptyRows, updateItem, deleteItem, restoreItem } =
     useBudgetItems(walletId);
-
-  const handleAddItem = async () => {
-    const result = await addItem();
-    return result.ok ? result.id : undefined;
-  };
 
   return (
     <div className="h-full flex flex-col">
       <BudgetTable
         items={items}
-        onAddItem={handleAddItem}
+        onAddItems={addItems}
+        onTrimRows={trimEmptyRows}
         onUpdateItem={updateItem}
         onDeleteItem={deleteItem}
         onRestoreItem={restoreItem}


### PR DESCRIPTION
## Summary
- **#16 Batch Add Rows**: "+ Add rows" button adds 5 empty rows at once via `bulkAdd`, auto-focuses first new row
- **#17 Trim Empty Rows**: "Trim" button removes consecutive empty rows from bottom (whitespace-only names count as empty). Button only visible when trailing rows are trimmable.
- **#20 Row Numbering**: Sequential row numbers (1, 2, 3...) displayed as first column with monospaced font

## What changed
- **`src/hooks/useBudgetItems.ts`** — New: `addItems` (bulkAdd 5 rows), `trimEmptyRows` (bulkDelete trailing empties). Both return discriminated union results with `as const`.
- **`src/components/Budget/BudgetRow.tsx`** — New: `rowNumber` prop rendered as first column (`w-8 font-mono`)
- **`src/components/Budget/BudgetTable.tsx`** — New: `onAddItems`/`onTrimRows` props with discriminated union types, Trim button with conditional visibility, `#` header column
- **`src/components/Budget/WalletDetailPage.tsx`** — Wires new hook functions to table

## Code review
Reviewed by ultrabrain. Findings addressed:
- Whitespace-only names treated as empty for trim (`name.trim()`)
- Discriminated union prop types (`AddItemsResult`, `TrimResult`)
- Trim button only visible when trailing rows are empty
- Row number column widened to `w-8` with `font-mono`

## Verification
- `npm run lint` ✅
- `npm run typecheck` ✅

Closes #16, closes #17, closes #20