### PR TITLE
fix: auto-focus timing race on add rows

### DIFF
--- a/src/components/Budget/BudgetRow.tsx
+++ b/src/components/Budget/BudgetRow.tsx
@@ -51,11 +51,16 @@ export function BudgetRow({
   }, [item.name, item.amount]);
 
   useEffect(() => {
-    if (autoFocus) {
-      nameInputRef.current?.focus();
+    if (!autoFocus) {
+      return;
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []); // Only on mount
+
+    const frame = requestAnimationFrame(() => {
+      nameInputRef.current?.focus();
+    });
+
+    return () => cancelAnimationFrame(frame);
+  }, [autoFocus]);
 
   if (!item.id) {
     return null;


### PR DESCRIPTION
## Summary
Focus effect had `[]` deps (mount-only), but rows could mount before `lastAddedId` state was set — liveQuery renders faster than React state update. Changed to `[autoFocus]` dep + `requestAnimationFrame` for reliable DOM timing.

Verified working with Playwright: click "+ Add rows" → focus lands on first new row's name input → typing works immediately.