### PR TITLE
fix: improve contrast and touch targets (#27, #28, #29)

### DIFF
--- a/src/components/Budget/BudgetRow.tsx
+++ b/src/components/Budget/BudgetRow.tsx
@@ -118,7 +118,7 @@ export function BudgetRow({
 
   return (
     <div
-      className={`flex items-center gap-2 py-2 border-b border-border ${
+      className={`flex items-center gap-2 py-2 min-h-[44px] border-b border-border ${
         item.type === '+'
           ? 'border-l-4 border-l-green-500 pl-2'
           : 'border-l-4 border-l-red-500 pl-2'
@@ -144,14 +144,18 @@ export function BudgetRow({
       <button
         type="button"
         onClick={toggleType}
-        className={`w-8 h-8 flex items-center justify-center rounded-full font-bold text-lg transition-colors ${
-          item.type === '+'
-            ? 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300'
-            : 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300'
-        }`}
+        className="min-w-[44px] min-h-[44px] flex items-center justify-center"
         aria-label={`Toggle type, currently ${item.type}`}
       >
-        {item.type}
+        <span
+          className={`w-8 h-8 flex items-center justify-center rounded-full font-bold text-lg transition-colors ${
+            item.type === '+'
+              ? 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300'
+              : 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300'
+          }`}
+        >
+          {item.type}
+        </span>
       </button>
 
       <div className="w-20 sm:w-24">
@@ -170,7 +174,7 @@ export function BudgetRow({
       <button
         type="button"
         onClick={handleDelete}
-        className="text-gray-400 hover:text-red-500 p-2 transition-colors"
+        className="text-gray-400 hover:text-red-500 p-3 transition-colors"
         aria-label="Delete item"
       >
         <svg

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -22,7 +22,7 @@ export function Header(): JSX.Element {
         {!isHome && (
           <button
             onClick={() => navigate('/')}
-            className="p-2 -ml-2 text-3xl leading-none text-text-primary hover:text-accent transition-colors cursor-pointer"
+            className="min-w-[44px] min-h-[44px] flex items-center justify-center -ml-2 text-3xl leading-none text-text-primary hover:text-accent transition-colors cursor-pointer"
             aria-label="Go back"
           >
             ‹

--- a/src/components/Settings/ThemeToggle.tsx
+++ b/src/components/Settings/ThemeToggle.tsx
@@ -8,7 +8,7 @@ export function ThemeToggle(): JSX.Element {
       type="button"
       onClick={toggleTheme}
       aria-label={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
-      className="rounded-lg p-2 text-2xl hover:bg-bg-secondary hover:border-accent transition-colors border border-transparent"
+      className="rounded-lg min-w-[44px] min-h-[44px] flex items-center justify-center text-2xl hover:bg-bg-secondary hover:border-accent transition-colors border border-transparent"
     >
       {theme === 'light' ? '🌙' : '☀️'}
     </button>

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -16,7 +16,7 @@
   --bg-secondary: #f5f5f5;
   --text-primary: #213547;
   --text-secondary: #6b7280;
-  --accent: #3b82f6;
+  --accent: #2563eb;
   --border: #e5e7eb;
 
   transition:


### PR DESCRIPTION
## Summary

Fixes accessibility issues found during Lighthouse audit and responsive testing:

- **Contrast**: Changed accent color from `#3b82f6` (blue-500) to `#2563eb` (blue-600) for WCAG AA compliance
- **Touch targets**: Added 44px minimum touch targets on type toggle, delete button, back button, and theme toggle
- **Row height**: Added `min-h-[44px]` on budget rows for consistent mobile tap area

## Testing

- Lighthouse audit: Performance 93, Accessibility 95, Best Practices 100
- Playwright offline testing: ALL PASS (9 scenarios)
- Playwright responsive testing: verified fixes on 375px and 768px viewports
- `npm run lint && npm run typecheck` ✅

Closes #27, #28, #29