### PR TITLE
chore: add vercel.json for SPA routing (#30, #31)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
## Summary

- Adds `vercel.json` with SPA rewrite rule so direct navigation to `/wallet/:id` routes works correctly on Vercel

Closes #30, #31