### PR TITLE
fix: update stale tests for delete flow changes

### DIFF
--- a/src/components/Budget/BudgetRow.test.tsx
+++ b/src/components/Budget/BudgetRow.test.tsx
@@ -23,7 +23,6 @@ describe('BudgetRow', () => {
     vi.useFakeTimers();
     mockUpdate.mockClear();
     mockDelete.mockClear();
-    window.confirm = vi.fn(() => true);
   });
 
   afterEach(() => {
@@ -96,25 +95,13 @@ describe('BudgetRow', () => {
     });
   });
 
-  it('handles delete with confirmation', () => {
+  it('deletes immediately without confirmation', () => {
     render(
       <BudgetRow item={item} rowNumber={1} onUpdate={mockUpdate} onDelete={mockDelete} />
     );
     const deleteBtn = screen.getByLabelText('Delete item');
     fireEvent.click(deleteBtn);
 
-    expect(window.confirm).toHaveBeenCalled();
     expect(mockDelete).toHaveBeenCalledWith('i1');
-  });
-
-  it('does not delete if confirmation cancelled', () => {
-    (window.confirm as unknown as ReturnType<typeof vi.fn>).mockReturnValue(false);
-    render(
-      <BudgetRow item={item} rowNumber={1} onUpdate={mockUpdate} onDelete={mockDelete} />
-    );
-    const deleteBtn = screen.getByLabelText('Delete item');
-    fireEvent.click(deleteBtn);
-
-    expect(mockDelete).not.toHaveBeenCalled();
   });
 });

--- a/src/components/Budget/BudgetTable.test.tsx
+++ b/src/components/Budget/BudgetTable.test.tsx
@@ -6,10 +6,10 @@ import type { BudgetItem } from '../../types';
 import { BudgetTable } from './BudgetTable';
 
 describe('BudgetTable', () => {
-  const mockAddItems = vi.fn();
+  const mockAddItems = vi.fn().mockResolvedValue({ ok: true, ids: [] });
   const mockTrimRows = vi.fn();
   const mockUpdateItem = vi.fn();
-  const mockDeleteItem = vi.fn();
+  const mockDeleteItem = vi.fn().mockResolvedValue({ ok: true });
 
   const items: BudgetItem[] = [
     {


### PR DESCRIPTION
## Summary

- **useBudgetItems.test.ts**: Add `mockGet` to mock since `deleteItem` now calls `db.budgetItems.get()` before deleting. Add not-found test case.
- **BudgetRow.test.tsx**: Remove `window.confirm` expectations — delete now fires immediately (undo toast handles reversal instead).
- **BudgetTable.test.tsx**: Mock `onAddItems` and `onDeleteItem` return values to prevent unhandled rejection.

All 127 tests pass.