### PR TITLE
feat: round compact buttons and tighter layout (#54, #55)

### DIFF
--- a/src/components/Budget/BudgetRow.tsx
+++ b/src/components/Budget/BudgetRow.tsx
@@ -118,14 +118,14 @@ export function BudgetRow({
 
   return (
     <div
-      className={`flex items-center gap-2 py-2 min-h-[44px] border-b border-border ${
+      className={`flex items-center gap-1 py-1.5 border-b border-border ${
         item.type === '+'
           ? 'border-l-4 border-l-green-500 pl-2'
           : 'border-l-4 border-l-red-500 pl-2'
       }`}
       role="row"
     >
-      <div className="text-xs text-text-secondary w-8 text-center flex-shrink-0 font-mono">
+      <div className="text-xs text-text-secondary w-6 text-center flex-shrink-0 font-mono">
         {rowNumber}
       </div>
       <div className="flex-grow min-w-0">
@@ -144,18 +144,14 @@ export function BudgetRow({
       <button
         type="button"
         onClick={toggleType}
-        className="min-w-[44px] min-h-[44px] flex items-center justify-center"
+        className={`h-7 w-7 flex items-center justify-center rounded-full text-sm font-semibold transition-colors ${
+          item.type === '+'
+            ? 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300'
+            : 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300'
+        }`}
         aria-label={`Toggle type, currently ${item.type}`}
       >
-        <span
-          className={`w-8 h-8 flex items-center justify-center rounded-full font-bold text-lg transition-colors ${
-            item.type === '+'
-              ? 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300'
-              : 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300'
-          }`}
-        >
-          {item.type}
-        </span>
+        {item.type}
       </button>
 
       <div className="w-20 sm:w-24">
@@ -174,7 +170,7 @@ export function BudgetRow({
       <button
         type="button"
         onClick={handleDelete}
-        className="text-gray-400 hover:text-red-500 p-3 transition-colors"
+        className="flex h-8 w-8 items-center justify-center rounded-full text-gray-400 dark:text-gray-500 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-950 transition-all"
         aria-label="Delete item"
       >
         <svg
@@ -183,7 +179,7 @@ export function BudgetRow({
           viewBox="0 0 24 24"
           strokeWidth={1.5}
           stroke="currentColor"
-          className="w-5 h-5"
+          className="w-[18px] h-[18px]"
         >
           <path
             strokeLinecap="round"

--- a/src/components/Budget/BudgetTable.tsx
+++ b/src/components/Budget/BudgetTable.tsx
@@ -96,20 +96,20 @@ export function BudgetTable({
 
   return (
     <div className="flex flex-col h-full w-full max-w-2xl mx-auto">
-      <div className="flex-grow overflow-auto pb-24 px-4">
+      <div className="flex-grow overflow-auto pb-20 px-2">
         {items.length === 0 ? (
-          <div className="flex flex-col items-center justify-center h-48 text-gray-400 gap-2">
+          <div className="flex flex-col items-center justify-center h-32 text-gray-400 gap-2">
             <p>No items yet.</p>
             <p>Tap &quot;Add item&quot; to start.</p>
           </div>
         ) : (
           <div className="flex flex-col">
-            <div className="flex px-2 py-2 text-xs font-semibold text-text-secondary uppercase tracking-wider border-b border-border">
-              <div className="w-8 text-center flex-shrink-0">#</div>
+            <div className="flex px-2 py-1.5 text-xs font-semibold text-text-secondary uppercase tracking-wider border-b border-border">
+              <div className="w-6 text-center flex-shrink-0">#</div>
               <div className="flex-grow pl-2">Name</div>
               <div className="w-8 text-center">Type</div>
               <div className="w-20 sm:w-24 text-right">Amount</div>
-              <div className="w-9"></div>
+              <div className="w-8"></div>
             </div>
             {items.map((item, index) => (
               <BudgetRow
@@ -125,11 +125,11 @@ export function BudgetTable({
           </div>
         )}
 
-        <div className="mt-6 flex gap-3">
+        <div className="mt-3 flex gap-3">
           <button
             type="button"
             onClick={handleAddItems}
-            className="flex-grow flex items-center justify-center py-3 border-2 border-dashed border-border rounded-lg text-gray-500 hover:text-gray-700 hover:border-gray-400 transition-colors"
+            className="flex-grow flex items-center justify-center py-2 border-2 border-dashed border-border rounded-lg text-gray-500 hover:text-gray-700 hover:border-gray-400 transition-colors"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -154,7 +154,7 @@ export function BudgetTable({
               <button
                 type="button"
                 onClick={handleTrimRows}
-                className="px-4 py-3 text-sm font-medium text-text-secondary hover:text-text-primary transition-colors border border-border rounded-lg"
+                className="px-4 py-2 text-sm font-medium text-text-secondary hover:text-text-primary transition-colors border border-border rounded-lg"
                 title="Remove empty rows from bottom"
               >
                 Trim
@@ -184,7 +184,7 @@ export function BudgetTable({
         </div>
       )}
 
-      <div className="fixed bottom-0 left-0 right-0 bg-bg-primary border-t border-border p-4 shadow-lg z-10">
+      <div className="fixed bottom-0 left-0 right-0 bg-bg-primary border-t border-border p-3 shadow-lg z-10">
         <div className="max-w-2xl mx-auto flex justify-between items-center text-xl font-bold">
           <span className="text-text-secondary">Total</span>
           <span

--- a/src/components/Budget/WalletDetailPage.tsx
+++ b/src/components/Budget/WalletDetailPage.tsx
@@ -36,12 +36,12 @@ export function WalletDetailPage(): JSX.Element {
 
   return (
     <div className="h-full flex flex-col">
-      <div className="flex justify-end px-4 pt-2">
+      <div className="flex justify-end px-2 pt-1">
         <button
           type="button"
           onClick={handleExport}
           disabled={exporting || !hasExportableItems}
-          className="p-2 text-text-secondary hover:text-text-primary disabled:opacity-50"
+          className="flex h-9 w-9 items-center justify-center rounded-full border border-border bg-bg-secondary text-text-secondary transition-all hover:border-accent hover:text-accent disabled:opacity-50 cursor-pointer"
           aria-label="Export PDF"
           aria-busy={exporting}
         >
@@ -73,7 +73,7 @@ export function WalletDetailPage(): JSX.Element {
               viewBox="0 0 24 24"
               strokeWidth={1.5}
               stroke="currentColor"
-              className="w-6 h-6"
+              className="w-5 h-5"
             >
               <path
                 strokeLinecap="round"

--- a/src/components/Home/FloatingActionButton.tsx
+++ b/src/components/Home/FloatingActionButton.tsx
@@ -12,7 +12,7 @@ export function FloatingActionButton({
       type="button"
       aria-label={label}
       onClick={onClick}
-      className="fixed bottom-6 right-6 w-14 h-14 bg-blue-600 text-white rounded-full shadow-lg flex items-center justify-center hover:bg-blue-700 focus:outline-none focus:ring-4 focus:ring-blue-300 active:scale-95 transition-transform z-50"
+      className="fixed bottom-6 right-6 w-14 h-14 bg-accent text-white rounded-full shadow-lg flex items-center justify-center hover:bg-accent/90 focus:outline-none focus:ring-4 focus:ring-blue-300 active:scale-95 transition-transform z-50"
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -20,7 +20,7 @@ export function FloatingActionButton({
         viewBox="0 0 24 24"
         strokeWidth={2}
         stroke="currentColor"
-        className="w-8 h-8"
+        className="w-7 h-7"
       >
         <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
       </svg>

--- a/src/components/Home/WalletList.tsx
+++ b/src/components/Home/WalletList.tsx
@@ -86,12 +86,12 @@ export function WalletList({
   }
 
   return (
-    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
       {walletsWithId.map((wallet, index) => (
         <Link
           key={wallet.id}
           to={`/wallet/${wallet.id}`}
-          className="group relative flex p-4 bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 hover:shadow-md hover:border-blue-200 dark:hover:border-blue-800 transition-all duration-200 items-stretch"
+          className="group relative flex p-3 bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 hover:shadow-md hover:border-blue-200 dark:hover:border-blue-800 transition-all duration-200 items-stretch"
         >
           <div className="flex flex-col justify-center mr-3 space-y-1">
             {index > 0 && (

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -1,19 +1,14 @@
-import { Outlet, useLocation } from 'react-router-dom';
+import { Outlet } from 'react-router-dom';
 
 import { Header } from './Header';
-import { BottomTotal } from './BottomTotal';
 
 export function AppLayout(): JSX.Element {
-  const location = useLocation();
-  const showFooter = location.pathname.startsWith('/wallet/');
-
   return (
     <div className="flex flex-col min-h-screen min-h-dvh bg-bg-primary text-text-primary">
       <Header />
-      <main className="flex-1 overflow-y-auto p-4 max-w-5xl mx-auto w-full pb-20">
+      <main className="flex-1 overflow-y-auto p-2 sm:p-4 max-w-5xl mx-auto w-full pb-16">
         <Outlet />
       </main>
-      {showFooter && <BottomTotal />}
     </div>
   );
 }

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -15,17 +15,30 @@ export function Header(): JSX.Element {
 
   return (
     <header
-      className="sticky top-0 z-50 flex items-center justify-between h-[56px] px-4 bg-bg-primary text-text-primary border-b border-border w-full"
+      className="sticky top-0 z-50 flex items-center justify-between h-12 px-4 bg-bg-primary text-text-primary border-b border-border w-full"
       data-testid="header"
     >
       <div className="flex items-center w-1/3">
         {!isHome && (
           <button
             onClick={() => navigate('/')}
-            className="min-w-[44px] min-h-[44px] flex items-center justify-center -ml-2 text-3xl leading-none text-text-primary hover:text-accent transition-colors cursor-pointer"
+            className="flex h-9 w-9 items-center justify-center -ml-2 rounded-full text-text-primary hover:text-accent hover:bg-bg-secondary transition-all cursor-pointer"
             aria-label="Go back"
           >
-            ‹
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={2}
+              stroke="currentColor"
+              className="w-5 h-5"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M15.75 19.5L8.25 12l7.5-7.5"
+              />
+            </svg>
           </button>
         )}
       </div>

--- a/src/components/Layout/pwaPrompts.css
+++ b/src/components/Layout/pwaPrompts.css
@@ -1,14 +1,16 @@
 .pwa-prompt {
   position: fixed;
+  left: 1rem;
   right: 1rem;
-  bottom: 1rem;
+  bottom: 4rem;
   max-width: 22rem;
   padding: 0.75rem 1rem;
   border: 1px solid var(--border);
   border-radius: 0.5rem;
   background: var(--bg-secondary);
   color: var(--text-primary);
-  z-index: 10;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  z-index: 30;
 }
 
 .pwa-prompt__actions {

--- a/src/components/Settings/ThemeToggle.tsx
+++ b/src/components/Settings/ThemeToggle.tsx
@@ -8,7 +8,7 @@ export function ThemeToggle(): JSX.Element {
       type="button"
       onClick={toggleTheme}
       aria-label={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
-      className="rounded-lg min-w-[44px] min-h-[44px] flex items-center justify-center text-2xl hover:bg-bg-secondary hover:border-accent transition-colors border border-transparent"
+      className="flex h-9 w-9 items-center justify-center rounded-full border border-border bg-bg-secondary text-base text-text-secondary transition-all hover:border-accent hover:text-accent cursor-pointer"
     >
       {theme === 'light' ? '🌙' : '☀️'}
     </button>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -24,7 +24,7 @@ body {
   min-height: 100vh;
 }
 
-button {
+button:not([class]) {
   border-radius: 8px;
   border: 1px solid transparent;
   padding: 0.6em 1.2em;
@@ -37,12 +37,12 @@ button {
   transition: border-color 0.25s;
 }
 
-button:hover {
+button:not([class]):hover {
   border-color: var(--accent);
 }
 
-button:focus,
-button:focus-visible {
+button:not([class]):focus,
+button:not([class]):focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 


### PR DESCRIPTION
## Summary

- Restyle all icon buttons to `rounded-full` with consistent sizing (`h-9 w-9` for inline, `w-14 h-14` for FAB)
- Compact layout: tighter padding, smaller gaps, `h-12` header
- Remove duplicate `BottomTotal` footer from `AppLayout`
- Fix invisible icons in dark mode by scoping global `button` CSS to `button:not([class])`
- Fix PWA install prompt overlap with budget total footer

## Changes

| File | What changed |
|------|-------------|
| `BudgetRow.tsx` | Small round type toggle + delete buttons |
| `BudgetTable.tsx` | Tighter padding and spacing |
| `WalletDetailPage.tsx` | Round export button |
| `FloatingActionButton.tsx` | `w-14 h-14`, `bg-accent`, `rounded-full` |
| `WalletList.tsx` | `gap-3`, `p-3` card padding |
| `AppLayout.tsx` | Removed `BottomTotal`, reduced padding |
| `Header.tsx` | `h-12`, round back button with SVG chevron |
| `ThemeToggle.tsx` | Round `h-9 w-9` button |
| `global.css` | `button` → `button:not([class])` (root cause of invisible icons) |
| `pwaPrompts.css` | `z-index: 30`, `bottom: 4rem` to float above total footer |

## Verification

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] Visual testing: all icons visible in light + dark mode
- [x] Install prompt floats correctly above total footer

Closes #54, closes #55