### PR TITLE
fix: auto-dismiss offline-ready prompt and prevent FAB overlap (#57)

### DIFF
--- a/src/components/Layout/AppLayout.test.tsx
+++ b/src/components/Layout/AppLayout.test.tsx
@@ -8,10 +8,6 @@ vi.mock('./Header', () => ({
   Header: () => <div data-testid="mock-header">Header</div>,
 }));
 
-vi.mock('./BottomTotal', () => ({
-  BottomTotal: () => <div data-testid="mock-bottom-total">BottomTotal</div>,
-}));
-
 describe('AppLayout', () => {
   it('renders Header and child content', () => {
     render(
@@ -25,19 +21,22 @@ describe('AppLayout', () => {
     );
     expect(screen.getByTestId('mock-header')).toBeInTheDocument();
     expect(screen.getByTestId('home-page')).toBeInTheDocument();
-    expect(screen.queryByTestId('mock-bottom-total')).not.toBeInTheDocument();
   });
 
-  it('shows BottomTotal on wallet detail route', () => {
+  it('renders Outlet for wallet detail route', () => {
     render(
       <MemoryRouter initialEntries={['/wallet/123']}>
         <Routes>
           <Route element={<AppLayout />}>
-            <Route path="/wallet/:id" element={<div>Wallet</div>} />
+            <Route
+              path="/wallet/:id"
+              element={<div data-testid="wallet-page">Wallet</div>}
+            />
           </Route>
         </Routes>
       </MemoryRouter>
     );
-    expect(screen.getByTestId('mock-bottom-total')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-header')).toBeInTheDocument();
+    expect(screen.getByTestId('wallet-page')).toBeInTheDocument();
   });
 });

--- a/src/components/Layout/pwaPrompts.css
+++ b/src/components/Layout/pwaPrompts.css
@@ -1,9 +1,10 @@
 .pwa-prompt {
   position: fixed;
   left: 1rem;
-  right: 1rem;
+  right: auto;
   bottom: 4rem;
-  max-width: 22rem;
+  width: auto;
+  max-width: min(22rem, calc(100vw - 6.5rem));
   padding: 0.75rem 1rem;
   border: 1px solid var(--border);
   border-radius: 0.5rem;

--- a/src/hooks/usePwaUpdatePrompt.ts
+++ b/src/hooks/usePwaUpdatePrompt.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useRegisterSW } from 'virtual:pwa-register/react';
 
 interface UsePwaUpdatePromptResult {
@@ -23,6 +23,17 @@ export function usePwaUpdatePrompt(): UsePwaUpdatePromptResult {
     offlineReady[1](false);
     needRefresh[1](false);
   }, [needRefresh, offlineReady]);
+
+  const isOfflineReady = offlineReady[0];
+
+  useEffect(() => {
+    if (isOfflineReady) {
+      const timer = setTimeout(() => {
+        dismiss();
+      }, 5000);
+      return () => clearTimeout(timer);
+    }
+  }, [isOfflineReady, dismiss]);
 
   return {
     offlineReady: offlineReady[0],


### PR DESCRIPTION
## Summary

- Auto-dismiss "App is ready to work offline" prompt after 5 seconds (needRefresh/update prompts still require user action)
- Left-align PWA prompts with `max-width: min(22rem, calc(100vw - 6.5rem))` to prevent overlap with FAB in bottom-right
- Fix stale AppLayout test that referenced removed BottomTotal component

## Changes

| File | What changed |
|------|-------------|
| `usePwaUpdatePrompt.ts` | Added `useEffect` auto-dismiss timer for `offlineReady` state |
| `pwaPrompts.css` | Left-aligned prompt, constrained width to avoid FAB area |
| `BudgetTable.tsx` | Moved `useMemo` above early return to fix conditional hook lint error |
| `AppLayout.test.tsx` | Removed stale BottomTotal mock and test (component was removed in #58) |

## Verification

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` — 127/127 tests pass

Closes #57