### PR TITLE
fix: format total with thousand separators

### DIFF
--- a/src/components/Budget/BudgetTable.test.tsx
+++ b/src/components/Budget/BudgetTable.test.tsx
@@ -75,7 +75,7 @@ describe('BudgetTable', () => {
     expect(screen.getByDisplayValue('Rent')).toBeInTheDocument();
 
     // Total should be 5000 - 1500 = 3500
-    expect(screen.getByText('+$3500.00')).toBeInTheDocument();
+    expect(screen.getByText('+$3,500.00')).toBeInTheDocument();
   });
 
   it('handles add item click', () => {

--- a/src/components/Budget/BudgetTable.tsx
+++ b/src/components/Budget/BudgetTable.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
 
 import type { BudgetItem } from '../../types';
+import { formatAmount } from '../../lib/format';
 
 import { BudgetRow } from './BudgetRow';
 
@@ -203,7 +204,7 @@ export function BudgetTable({
                 : 'text-red-600 dark:text-red-400'
             }
           >
-            {total >= 0 ? '+' : '-'}${Math.abs(total).toFixed(2)}
+            {total >= 0 ? '+' : '-'}${formatAmount(Math.abs(total))}
           </span>
         </div>
       </div>

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,6 @@
+export function formatAmount(value: number): string {
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}

--- a/src/lib/pdf.ts
+++ b/src/lib/pdf.ts
@@ -3,6 +3,8 @@ import autoTable from 'jspdf-autotable';
 
 import type { BudgetItem } from '../types';
 
+import { formatAmount } from './format';
+
 export function generatePdf(walletName: string, items: BudgetItem[]): Blob {
   const doc = new jsPDF();
   const pageWidth = doc.internal.pageSize.getWidth();
@@ -25,15 +27,7 @@ export function generatePdf(walletName: string, items: BudgetItem[]): Blob {
     if (item.type === '+') totalIncome += item.amount;
     else totalExpenses += item.amount;
 
-    return [
-      index + 1,
-      item.name,
-      item.type,
-      item.amount.toLocaleString(undefined, {
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2,
-      }),
-    ];
+    return [index + 1, item.name, item.type, formatAmount(item.amount)];
   });
 
   const balance = totalIncome - totalExpenses;
@@ -54,9 +48,9 @@ export function generatePdf(walletName: string, items: BudgetItem[]): Blob {
       }
     },
     foot: [
-      ['', '', 'Income', totalIncome.toFixed(2)],
-      ['', '', 'Expenses', totalExpenses.toFixed(2)],
-      ['', '', 'Balance', balance.toFixed(2)],
+      ['', '', 'Income', formatAmount(totalIncome)],
+      ['', '', 'Expenses', formatAmount(totalExpenses)],
+      ['', '', 'Balance', formatAmount(balance)],
     ],
     theme: 'striped',
     headStyles: { fillColor: [66, 66, 66] },


### PR DESCRIPTION
## Summary

Total footer showed `+$3500.00` instead of `+$3,500.00`. PDF export footer had the same issue.

## Changes

- New `src/lib/format.ts` — shared `formatAmount()` using `toLocaleString` (respects user locale)
- `BudgetTable.tsx` — total footer uses `formatAmount()` 
- `pdf.ts` — row amounts and footer totals use `formatAmount()`

## Verification

- [x] `npm run lint && npm run typecheck && npm test` — all pass (127/127)

User feedback fix.