### PR TITLE
feat: show iOS Safari install instructions (#62)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,14 +4,17 @@ import { HomePage } from './components/Home/HomePage';
 import { NotFoundPage } from './components/Home/NotFoundPage';
 import { WalletDetailPage } from './components/Budget/WalletDetailPage';
 import { InstallPrompt } from './components/Layout/InstallPrompt';
+import { IOSInstallPrompt } from './components/Layout/IOSInstallPrompt';
 import { ReloadPrompt } from './components/Layout/ReloadPrompt';
 import { AppLayout } from './components/Layout/AppLayout';
 import { useInstallPrompt } from './hooks/useInstallPrompt';
+import { useIOSInstallPrompt } from './hooks/useIOSInstallPrompt';
 import { usePwaUpdatePrompt } from './hooks/usePwaUpdatePrompt';
 import './components/Layout/pwaPrompts.css';
 
 export function App(): JSX.Element {
   const { isInstallable, isInstalled, promptInstall } = useInstallPrompt();
+  const { shouldShow: showIOSPrompt, dismiss: dismissIOSPrompt } = useIOSInstallPrompt();
   const { offlineReady, needRefresh, updateServiceWorker, dismiss } =
     usePwaUpdatePrompt();
 
@@ -28,6 +31,7 @@ export function App(): JSX.Element {
         isInstalled={isInstalled}
         onInstall={promptInstall}
       />
+      <IOSInstallPrompt shouldShow={showIOSPrompt} onDismiss={dismissIOSPrompt} />
       <Routes>
         <Route element={<AppLayout />}>
           <Route path="/" element={<HomePage />} />

--- a/src/components/Layout/IOSInstallPrompt.tsx
+++ b/src/components/Layout/IOSInstallPrompt.tsx
@@ -1,0 +1,55 @@
+import './pwaPrompts.css';
+
+interface IOSInstallPromptProps {
+  shouldShow: boolean;
+  onDismiss: () => void;
+}
+
+export function IOSInstallPrompt({
+  shouldShow,
+  onDismiss,
+}: IOSInstallPromptProps): JSX.Element | null {
+  if (!shouldShow) {
+    return null;
+  }
+
+  return (
+    <div
+      className="pwa-prompt"
+      role="dialog"
+      aria-live="polite"
+      aria-label="Install app instructions"
+    >
+      <div className="mb-2">
+        <p className="mb-2 font-medium">Install Cuentica</p>
+        <p className="text-sm">
+          Tap the <ShareIcon /> icon below, then select{' '}
+          <span className="font-bold">Add to Home Screen</span>.
+        </p>
+      </div>
+      <div className="pwa-prompt__actions">
+        <button type="button" onClick={onDismiss}>
+          Close
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ShareIcon(): JSX.Element {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="inline-block w-5 h-5 mx-1 align-text-bottom"
+    >
+      <path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8" />
+      <polyline points="16 6 12 2 8 6" />
+      <line x1="12" y1="2" x2="12" y2="15" />
+    </svg>
+  );
+}

--- a/src/hooks/useIOSInstallPrompt.ts
+++ b/src/hooks/useIOSInstallPrompt.ts
@@ -1,0 +1,49 @@
+import { useState, useEffect } from 'react';
+
+const IOS_PROMPT_DISMISS_KEY = 'ios-install-prompt-dismissed';
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+
+interface UseIOSInstallPrompt {
+  shouldShow: boolean;
+  dismiss: () => void;
+}
+
+export function useIOSInstallPrompt(): UseIOSInstallPrompt {
+  const [shouldShow, setShouldShow] = useState(false);
+
+  useEffect(() => {
+    const isIOS =
+      /iPad|iPhone|iPod/.test(navigator.userAgent) ||
+      (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+
+    if (!isIOS) {
+      return;
+    }
+
+    const isStandalone =
+      window.matchMedia('(display-mode: standalone)').matches ||
+      ('standalone' in navigator &&
+        (navigator as unknown as { standalone: boolean }).standalone === true);
+
+    if (isStandalone) {
+      return;
+    }
+
+    const dismissedAt = localStorage.getItem(IOS_PROMPT_DISMISS_KEY);
+    if (dismissedAt) {
+      const dismissedTime = parseInt(dismissedAt, 10);
+      if (Date.now() - dismissedTime < THIRTY_DAYS_MS) {
+        return;
+      }
+    }
+
+    setShouldShow(true);
+  }, []);
+
+  const dismiss = () => {
+    localStorage.setItem(IOS_PROMPT_DISMISS_KEY, Date.now().toString());
+    setShouldShow(false);
+  };
+
+  return { shouldShow, dismiss };
+}


### PR DESCRIPTION
## Summary

iOS Safari doesn't support `beforeinstallprompt`, so iPhone users never saw an install option. This adds a custom instructional banner that teaches users to tap Share → Add to Home Screen.

## Changes

| File | What changed |
|------|-------------|
| `useIOSInstallPrompt.ts` | New hook — detects iOS Safari, standalone mode, 30-day dismiss cooldown |
| `IOSInstallPrompt.tsx` | New component — instructional banner with share icon, uses `.pwa-prompt` class |
| `App.tsx` | Wire up the new iOS prompt alongside existing Chrome/Android prompt |

## Behavior

- **iOS Safari**: Shows "Tap the ↗️ icon below, then select Add to Home Screen"
- **Already installed (standalone)**: Hidden
- **Dismissed**: Hidden for 30 days
- **Android/Chrome**: Not shown (existing `beforeinstallprompt` handles it)

## Verification

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` — 127/127 tests pass

Closes #62