### PR TITLE
feat: migrate local data to cloud on first sign-in (#66)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { ReloadPrompt } from './components/Layout/ReloadPrompt';
 import { AppLayout } from './components/Layout/AppLayout';
 import { useInstallPrompt } from './hooks/useInstallPrompt';
 import { useIOSInstallPrompt } from './hooks/useIOSInstallPrompt';
+import { useMigration } from './hooks/useMigration';
 import { usePwaUpdatePrompt } from './hooks/usePwaUpdatePrompt';
 import './components/Layout/pwaPrompts.css';
 
@@ -18,6 +19,7 @@ export function App(): JSX.Element {
   const { shouldShow: showIOSPrompt, dismiss: dismissIOSPrompt } = useIOSInstallPrompt();
   const { offlineReady, needRefresh, updateServiceWorker, dismiss } =
     usePwaUpdatePrompt();
+  const { migrating, error, retry } = useMigration();
 
   return (
     <>
@@ -41,6 +43,37 @@ export function App(): JSX.Element {
           <Route path="*" element={<NotFoundPage />} />
         </Route>
       </Routes>
+      {(migrating || error) && (
+        <div className="fixed inset-0 z-[80] flex items-center justify-center bg-bg-primary/95 px-6">
+          <div className="flex w-full max-w-sm flex-col items-center gap-4 rounded-xl border border-border bg-bg-primary p-6 text-center shadow-xl">
+            <h2 className="text-lg font-semibold text-text-primary">
+              Syncing your data...
+            </h2>
+            {migrating ? (
+              <>
+                <div
+                  className="h-8 w-8 animate-spin rounded-full border-2 border-accent border-t-transparent"
+                  aria-label="Sync in progress"
+                />
+                <p className="text-sm text-text-secondary">
+                  Please keep this tab open while we sync your wallets and budget items.
+                </p>
+              </>
+            ) : (
+              <>
+                <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+                <button
+                  type="button"
+                  onClick={retry}
+                  className="rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90 cursor-pointer"
+                >
+                  Retry
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+      )}
     </>
   );
 }

--- a/src/components/Layout/Header.test.tsx
+++ b/src/components/Layout/Header.test.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect, vi } from 'vitest';
 
 import { AuthProvider } from '../../context/AuthContext';
+
 import { Header } from './Header';
 
 vi.mock('../Settings/ThemeToggle', () => ({

--- a/src/hooks/useMigration.ts
+++ b/src/hooks/useMigration.ts
@@ -1,0 +1,90 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { useAuth } from '../context/AuthContext';
+import { migrateLocalDataForUser } from '../lib/migration';
+
+interface UseMigrationResult {
+  migrating: boolean;
+  error: string | null;
+  retry: () => void;
+}
+
+const migrationFlagKey = (userId: string): string => `cuentica-migration-${userId}`;
+
+const isMigrationDone = (userId: string): boolean =>
+  localStorage.getItem(migrationFlagKey(userId)) === 'done';
+
+const setMigrationDone = (userId: string): void => {
+  localStorage.setItem(migrationFlagKey(userId), 'done');
+};
+
+export function useMigration(): UseMigrationResult {
+  const { user, loading, isConfigured } = useAuth();
+  const [migrating, setMigrating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [attempt, setAttempt] = useState(0);
+  const runningRef = useRef(false);
+
+  const retry = useCallback((): void => {
+    setAttempt((previousAttempt) => previousAttempt + 1);
+  }, []);
+
+  useEffect(() => {
+    if (loading || !isConfigured || !user) {
+      return;
+    }
+
+    if (isMigrationDone(user.id)) {
+      return;
+    }
+
+    if (runningRef.current) {
+      return;
+    }
+
+    runningRef.current = true;
+    setMigrating(true);
+    setError(null);
+
+    let isMounted = true;
+
+    migrateLocalDataForUser(user.id)
+      .then(() => {
+        if (!isMounted) {
+          return;
+        }
+
+        setMigrationDone(user.id);
+      })
+      .catch((migrationError: unknown) => {
+        if (!isMounted) {
+          return;
+        }
+
+        const message =
+          migrationError instanceof Error
+            ? migrationError.message
+            : 'Data migration failed';
+        setError(message);
+      })
+      .finally(() => {
+        runningRef.current = false;
+
+        if (!isMounted) {
+          return;
+        }
+
+        setMigrating(false);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [attempt, isConfigured, loading, user]);
+
+  return {
+    migrating,
+    error,
+    retry,
+  };
+}

--- a/src/lib/migration.ts
+++ b/src/lib/migration.ts
@@ -1,0 +1,263 @@
+import type { BudgetItem, Wallet } from '../types';
+
+import { db } from './db';
+import { supabase } from './supabase';
+
+type SyncStatus = 'pending' | 'synced';
+
+type WalletWithId = Wallet & { id: string };
+type BudgetItemWithId = BudgetItem & { id: string };
+
+interface LocalMigrationData {
+  wallets: WalletWithId[];
+  budgetItems: BudgetItemWithId[];
+}
+
+interface SupabaseWalletRow {
+  id: string;
+  user_id: string;
+  name: string;
+  order: number;
+  color: string | null;
+  category_id: string | null;
+  created_at: number;
+  updated_at: number;
+  sync_status: SyncStatus;
+  deleted: boolean;
+}
+
+interface SupabaseBudgetItemRow {
+  id: string;
+  user_id: string;
+  wallet_id: string;
+  order: number;
+  name: string;
+  type: '+' | '-';
+  amount: number | string;
+  date: string | null;
+  category_tag: string | null;
+  created_at: number;
+  updated_at: number;
+  sync_status: SyncStatus;
+  deleted: boolean;
+}
+
+export type MigrationMode = 'skipped-empty' | 'pushed' | 'pulled';
+
+const toSupabaseWallet = (wallet: WalletWithId, userId: string): SupabaseWalletRow => ({
+  id: wallet.id,
+  user_id: userId,
+  name: wallet.name,
+  order: wallet.order,
+  color: wallet.color ?? null,
+  category_id: wallet.categoryId ?? null,
+  created_at: wallet.createdAt,
+  updated_at: wallet.updatedAt,
+  sync_status: wallet.syncStatus ?? 'pending',
+  deleted: wallet.deleted ?? false,
+});
+
+const toSupabaseBudgetItem = (
+  budgetItem: BudgetItemWithId,
+  userId: string
+): SupabaseBudgetItemRow => ({
+  id: budgetItem.id,
+  user_id: userId,
+  wallet_id: budgetItem.walletId,
+  order: budgetItem.order,
+  name: budgetItem.name,
+  type: budgetItem.type,
+  amount: budgetItem.amount,
+  date: budgetItem.date ?? null,
+  category_tag: budgetItem.categoryTag ?? null,
+  created_at: budgetItem.createdAt,
+  updated_at: budgetItem.updatedAt,
+  sync_status: budgetItem.syncStatus ?? 'pending',
+  deleted: budgetItem.deleted ?? false,
+});
+
+const toLocalWallet = (wallet: SupabaseWalletRow): WalletWithId => ({
+  id: wallet.id,
+  name: wallet.name,
+  order: wallet.order,
+  color: wallet.color ?? undefined,
+  categoryId: wallet.category_id ?? undefined,
+  createdAt: wallet.created_at,
+  updatedAt: wallet.updated_at,
+  syncStatus: wallet.sync_status,
+  deleted: wallet.deleted,
+});
+
+const toLocalBudgetItem = (budgetItem: SupabaseBudgetItemRow): BudgetItemWithId => ({
+  id: budgetItem.id,
+  walletId: budgetItem.wallet_id,
+  order: budgetItem.order,
+  name: budgetItem.name,
+  type: budgetItem.type,
+  amount: (() => {
+    const parsed =
+      typeof budgetItem.amount === 'number'
+        ? budgetItem.amount
+        : Number.parseFloat(budgetItem.amount);
+    if (!Number.isFinite(parsed)) {
+      throw new Error(`Invalid amount value for budget item ${budgetItem.id}`);
+    }
+    return parsed;
+  })(),
+  date: budgetItem.date ?? undefined,
+  categoryTag: budgetItem.category_tag ?? undefined,
+  createdAt: budgetItem.created_at,
+  updatedAt: budgetItem.updated_at,
+  syncStatus: budgetItem.sync_status,
+  deleted: budgetItem.deleted,
+});
+
+const hasId = <T extends { id?: string }>(entity: T): entity is T & { id: string } =>
+  typeof entity.id === 'string' && entity.id.length > 0;
+
+const assertSupabaseConfigured = (): NonNullable<typeof supabase> => {
+  if (!supabase) {
+    throw new Error('Supabase not configured');
+  }
+
+  return supabase;
+};
+
+export async function readLocalMigrationData(): Promise<LocalMigrationData> {
+  const [wallets, budgetItems] = await Promise.all([
+    db.wallets.filter((wallet) => !wallet.deleted).toArray(),
+    db.budgetItems.filter((item) => !item.deleted).toArray(),
+  ]);
+
+  return {
+    wallets: wallets.filter(hasId),
+    budgetItems: budgetItems.filter(hasId),
+  };
+}
+
+export async function upsertLocalDataToSupabase(userId: string): Promise<void> {
+  const client = assertSupabaseConfigured();
+  const localData = await readLocalMigrationData();
+
+  const walletsPayload = localData.wallets.map((wallet) =>
+    toSupabaseWallet(wallet, userId)
+  );
+  const budgetItemsPayload = localData.budgetItems.map((item) =>
+    toSupabaseBudgetItem(item, userId)
+  );
+
+  if (walletsPayload.length > 0) {
+    const { error } = await client
+      .from('wallets')
+      .upsert(walletsPayload, { onConflict: 'id' });
+
+    if (error) {
+      throw new Error(error.message);
+    }
+  }
+
+  if (budgetItemsPayload.length > 0) {
+    const { error } = await client
+      .from('budget_items')
+      .upsert(budgetItemsPayload, { onConflict: 'id' });
+
+    if (error) {
+      throw new Error(error.message);
+    }
+  }
+
+  if (localData.wallets.length > 0 || localData.budgetItems.length > 0) {
+    await db.transaction('rw', db.wallets, db.budgetItems, async () => {
+      if (localData.wallets.length > 0) {
+        await db.wallets.bulkPut(
+          localData.wallets.map((wallet) => ({ ...wallet, syncStatus: 'synced' }))
+        );
+      }
+
+      if (localData.budgetItems.length > 0) {
+        await db.budgetItems.bulkPut(
+          localData.budgetItems.map((item) => ({ ...item, syncStatus: 'synced' }))
+        );
+      }
+    });
+  }
+}
+
+export async function cloudHasDataForUser(userId: string): Promise<boolean> {
+  const client = assertSupabaseConfigured();
+  const { data, error } = await client
+    .from('wallets')
+    .select('id')
+    .eq('user_id', userId)
+    .eq('deleted', false)
+    .limit(1);
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return (data?.length ?? 0) > 0;
+}
+
+export async function pullSupabaseDataToLocal(userId: string): Promise<void> {
+  const client = assertSupabaseConfigured();
+  const [walletsResponse, budgetItemsResponse] = await Promise.all([
+    client
+      .from('wallets')
+      .select(
+        'id,user_id,name,order,color,category_id,created_at,updated_at,sync_status,deleted'
+      )
+      .eq('user_id', userId)
+      .eq('deleted', false),
+    client
+      .from('budget_items')
+      .select(
+        'id,user_id,wallet_id,order,name,type,amount,date,category_tag,created_at,updated_at,sync_status,deleted'
+      )
+      .eq('user_id', userId)
+      .eq('deleted', false),
+  ]);
+
+  if (walletsResponse.error) {
+    throw new Error(walletsResponse.error.message);
+  }
+
+  if (budgetItemsResponse.error) {
+    throw new Error(budgetItemsResponse.error.message);
+  }
+
+  const wallets = (walletsResponse.data ?? []).map((wallet) =>
+    toLocalWallet(wallet as SupabaseWalletRow)
+  );
+  const budgetItems = (budgetItemsResponse.data ?? []).map((item) =>
+    toLocalBudgetItem(item as SupabaseBudgetItemRow)
+  );
+
+  await db.transaction('rw', db.wallets, db.budgetItems, async () => {
+    if (wallets.length > 0) {
+      await db.wallets.bulkPut(wallets);
+    }
+
+    if (budgetItems.length > 0) {
+      await db.budgetItems.bulkPut(budgetItems);
+    }
+  });
+}
+
+export async function migrateLocalDataForUser(userId: string): Promise<MigrationMode> {
+  const localData = await readLocalMigrationData();
+
+  if (localData.wallets.length === 0 && localData.budgetItems.length === 0) {
+    const hasCloudData = await cloudHasDataForUser(userId);
+
+    if (hasCloudData) {
+      await pullSupabaseDataToLocal(userId);
+      return 'pulled';
+    }
+
+    return 'skipped-empty';
+  }
+
+  await upsertLocalDataToSupabase(userId);
+  return 'pushed';
+}


### PR DESCRIPTION
## Summary

Adds automatic migration of local Dexie.js data to Supabase when a user signs in for the first time. Handles both push (local → cloud) and pull (cloud → local for second devices).

Closes #66

## What Changed

- **`src/lib/migration.ts`** (NEW) — Pure functions for bidirectional data migration:
  - `migrateLocalDataForUser(userId)` — orchestrates: if local has data → push to cloud; if local empty but cloud has data → pull to local; if both empty → skip
  - camelCase ↔ snake_case mapping between Dexie and Supabase schemas
  - Upserts with `onConflict: 'id'` for idempotency
  - Wallets upserted before budget_items (FK constraint)
  - Marks local records as `syncStatus: 'synced'` after successful push
  - Validates `amount` values during pull (throws on NaN)

- **`src/hooks/useMigration.ts`** (NEW) — React hook:
  - Watches auth state, triggers migration when user signs in
  - Per-user localStorage flag (`cuentica-migration-{userId}`) to avoid re-running
  - Exposes `{ migrating, error, retry }`
  - `isMounted` guard for cleanup, `runningRef` to prevent concurrent runs

- **`src/App.tsx`** (MODIFIED) — Full-screen overlay during migration with spinner + retry button on failure

## Code Review

- 0 critical, 0 major after fixes
- 2 findings deferred to #75 (cross-account data leak on shared device, StrictMode double-mount race — both low production risk)

## Verification

- `npm run lint` ✅
- `npm run typecheck` ✅