### PR TITLE
design: add text labels to icon-only action buttons (#89)

### DIFF
--- a/src/components/Budget/WalletDetailPage.tsx
+++ b/src/components/Budget/WalletDetailPage.tsx
@@ -9,8 +9,12 @@ import { sharePdf } from '../../lib/share';
 
 import { BudgetTable } from './BudgetTable';
 
-const actionButtonClassName =
-  'flex h-8 w-8 items-center justify-center rounded-full border border-border bg-bg-secondary text-text-secondary transition-colors hover:border-accent hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/30 disabled:cursor-not-allowed disabled:opacity-50 cursor-pointer';
+const baseActionButtonClassName =
+  'flex items-center justify-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/30 disabled:cursor-not-allowed disabled:opacity-50 cursor-pointer';
+
+const secondaryActionButtonClassName = `${baseActionButtonClassName} border border-border bg-bg-secondary text-text-secondary hover:border-accent hover:text-accent`;
+
+const primaryActionButtonClassName = `${baseActionButtonClassName} bg-accent text-white hover:bg-accent/90`;
 
 export function WalletDetailPage(): JSX.Element {
   const { id } = useParams<{ id: string }>();
@@ -61,7 +65,7 @@ export function WalletDetailPage(): JSX.Element {
             void handleCopy();
           }}
           disabled={!canCopy}
-          className={actionButtonClassName}
+          className={secondaryActionButtonClassName}
           aria-label="Copy items"
           title="Copy items"
         >
@@ -80,13 +84,14 @@ export function WalletDetailPage(): JSX.Element {
               d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125H4.125A1.125 1.125 0 0 1 3 20.625V8.625c0-.621.504-1.125 1.125-1.125H7.5m8.25 9.75h4.125c.621 0 1.125-.504 1.125-1.125V4.125A1.125 1.125 0 0 0 19.875 3H9.375C8.754 3 8.25 3.504 8.25 4.125V7.5"
             />
           </svg>
+          <span>Copy</span>
         </button>
         <button
           type="button"
           onClick={() => {
             void handlePaste();
           }}
-          className={actionButtonClassName}
+          className={secondaryActionButtonClassName}
           aria-label="Paste items"
           title="Paste items"
         >
@@ -105,12 +110,13 @@ export function WalletDetailPage(): JSX.Element {
               d="M9 5.25h6m-6 3h6m-9 9h12a2.25 2.25 0 0 0 2.25-2.25V5.625A2.625 2.625 0 0 0 17.625 3H15A2.25 2.25 0 0 0 12.75.75h-1.5A2.25 2.25 0 0 0 9 3H6.375A2.625 2.625 0 0 0 3.75 5.625V15A2.25 2.25 0 0 0 6 17.25Z"
             />
           </svg>
+          <span>Paste</span>
         </button>
         <button
           type="button"
           onClick={handleExport}
           disabled={exporting || !hasExportableItems}
-          className={actionButtonClassName}
+          className={primaryActionButtonClassName}
           aria-label="Export PDF"
           aria-busy={exporting}
           title="Export PDF"
@@ -154,6 +160,7 @@ export function WalletDetailPage(): JSX.Element {
               />
             </svg>
           )}
+          <span>Export PDF</span>
         </button>
       </div>
       <BudgetTable


### PR DESCRIPTION
## Summary
- Added visible text labels ("Copy", "Paste", "Export PDF") to the icon-only action buttons on WalletDetailPage
- Export PDF button styled as primary action (accent color) since it's the app's key differentiator
- Copy/Paste buttons keep secondary styling (border, bg-secondary)

## Changes
- `src/components/Budget/WalletDetailPage.tsx`: Split `actionButtonClassName` into base/secondary/primary variants, added `<span>` labels to each button, changed shape from circles (`rounded-full h-8 w-8`) to pills (`rounded-lg px-3 py-1.5`)

## Verification
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm test` ✅ (149 tests pass)

Closes #89
