### PR TITLE
design: improve discoverability — rename pencil, toggle tooltip, FAB label

### DIFF
--- a/src/components/Budget/BudgetRow.test.tsx
+++ b/src/components/Budget/BudgetRow.test.tsx
@@ -37,14 +37,14 @@ describe('BudgetRow', () => {
     );
     expect(screen.getByLabelText('Item name')).toHaveValue('Rent');
     expect(screen.getByLabelText('Amount')).toHaveValue(1000);
-    expect(screen.getByLabelText('Toggle type, currently -')).toBeInTheDocument();
+    expect(screen.getByLabelText('Toggle type, currently expense')).toBeInTheDocument();
   });
 
   it('toggles type immediately', () => {
     render(
       <BudgetRow item={item} rowNumber={1} onUpdate={mockUpdate} onDelete={mockDelete} />
     );
-    const toggleBtn = screen.getByLabelText('Toggle type, currently -');
+    const toggleBtn = screen.getByLabelText('Toggle type, currently expense');
     fireEvent.click(toggleBtn);
     expect(mockUpdate).toHaveBeenCalledWith('i1', { type: '+' });
   });

--- a/src/components/Budget/BudgetRow.tsx
+++ b/src/components/Budget/BudgetRow.tsx
@@ -204,7 +204,8 @@ function BudgetRowComponent({
             ? 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300'
             : 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300'
         }`}
-        aria-label={`Toggle type, currently ${item.type}`}
+        aria-label={`Toggle type, currently ${item.type === '+' ? 'income' : 'expense'}`}
+        title={item.type === '+' ? 'Income — tap to switch' : 'Expense — tap to switch'}
       >
         {item.type}
       </button>

--- a/src/components/Home/FloatingActionButton.tsx
+++ b/src/components/Home/FloatingActionButton.tsx
@@ -12,7 +12,7 @@ export function FloatingActionButton({
       type="button"
       aria-label={label}
       onClick={onClick}
-      className="fixed bottom-6 right-6 w-14 h-14 bg-accent text-white rounded-full shadow-lg flex items-center justify-center hover:bg-accent/90 focus:outline-none focus:ring-4 focus:ring-accent/50 active:scale-95 transition-transform z-50"
+      className="fixed bottom-6 right-6 h-12 bg-accent text-white rounded-full shadow-lg flex items-center gap-2 px-5 hover:bg-accent/90 focus:outline-none focus:ring-4 focus:ring-accent/50 active:scale-95 transition-transform z-50"
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -20,10 +20,11 @@ export function FloatingActionButton({
         viewBox="0 0 24 24"
         strokeWidth={2}
         stroke="currentColor"
-        className="w-7 h-7"
+        className="w-5 h-5"
       >
         <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
       </svg>
+      <span className="text-sm font-semibold">{label}</span>
     </button>
   );
 }

--- a/src/components/Home/WalletList.tsx
+++ b/src/components/Home/WalletList.tsx
@@ -170,10 +170,25 @@ function SortableWalletCard({
                     onStartEdit(e, wallet);
                   }
                 }}
-                className="text-lg font-semibold text-text-primary truncate group-hover:text-accent transition-colors cursor-text hover:underline decoration-dashed underline-offset-4 decoration-border"
-                title="Click to rename"
+                className="text-lg font-semibold text-text-primary truncate group-hover:text-accent transition-colors hover:underline decoration-dashed underline-offset-4 decoration-border flex items-center"
+                title="Tap to rename"
               >
                 {wallet.name}
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth={1.5}
+                  stroke="currentColor"
+                  className="h-3.5 w-3.5 flex-shrink-0 ml-1.5 text-text-muted"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10"
+                  />
+                </svg>
               </div>
             )}
             {editingWalletId !== wallet.id && (


### PR DESCRIPTION
## Summary
Fixes three discoverability issues identified in the design critique where interactive elements were invisible or unclear on mobile.

### Wallet rename affordance
- Added a subtle pencil icon (✏️ SVG) next to wallet names in WalletList — always visible, not hover-dependent
- Changed title tooltip from "Click to rename" to "Tap to rename"

### Type toggle clarity
- Improved aria-label to human-readable "income" / "expense" (was raw "+"/"-")
- Added title tooltip: "Income — tap to switch" / "Expense — tap to switch"

### FAB visible label
- Changed from icon-only circle to pill-shaped button with visible "Add Wallet" text
- Reduced icon size, added gap and padding for text

## Changes
- `src/components/Home/WalletList.tsx`: Pencil icon + title update
- `src/components/Budget/BudgetRow.tsx`: aria-label + title improvements
- `src/components/Budget/BudgetRow.test.tsx`: Updated test for new aria-label
- `src/components/Home/FloatingActionButton.tsx`: Pill shape with visible label

## Verification
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm test` ✅ (151 tests pass)

Part of #87
