### PR TITLE
design: add contextual first-use hints for reorder and type toggle

### DIFF
--- a/src/components/Budget/BudgetTable.tsx
+++ b/src/components/Budget/BudgetTable.tsx
@@ -17,6 +17,7 @@ import {
 } from '@dnd-kit/sortable';
 import { restrictToVerticalAxis } from '@dnd-kit/modifiers';
 
+import { useHint } from '../../hooks/useHint';
 import { useToast } from '../../context/ToastContext';
 import type { BudgetItem } from '../../types';
 import { formatAmount } from '../../lib/format';
@@ -51,6 +52,7 @@ export function BudgetTable({
   const [deletedItems, setDeletedItems] = useState<BudgetItem[]>([]);
   const [lastAddedId, setLastAddedId] = useState<string | null>(null);
   const { showToast } = useToast();
+  const { visible: typeHintVisible, dismiss: dismissTypeHint } = useHint('type-toggle');
 
   const sensors = useSensors(
     useSensor(MouseSensor, {
@@ -268,6 +270,50 @@ export function BudgetTable({
               <div className="w-20 sm:w-24 text-right">Amount</div>
               <div className="w-16"></div>
             </div>
+            {items.length > 0 && typeHintVisible && (
+              <div className="flex items-center gap-2 px-3 py-2 mb-2 mt-2 text-xs text-accent bg-accent/5 rounded-lg mx-2">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth={1.5}
+                  stroke="currentColor"
+                  className="h-4 w-4 flex-shrink-0"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M12 18v-5.25m0 0a6.01 6.01 0 0 0 1.5-.189m-1.5.189a6.01 6.01 0 0 1-1.5-.189m3.75 7.478a12.06 12.06 0 0 1-4.5 0m3.75 2.383a14.406 14.406 0 0 1-3 0M14.25 18v-.192c0-.983.658-1.823 1.508-2.316a7.5 7.5 0 1 0-7.517 0c.85.493 1.509 1.333 1.509 2.316V18"
+                  />
+                </svg>
+                <p className="flex-1">
+                  Tap the colored +/- circle to switch between income and expense
+                </p>
+                <button
+                  type="button"
+                  onClick={dismissTypeHint}
+                  className="flex-shrink-0 text-text-muted hover:text-text-primary transition-colors cursor-pointer"
+                  aria-label="Dismiss tip"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    strokeWidth={1.5}
+                    stroke="currentColor"
+                    className="h-3.5 w-3.5"
+                    aria-hidden="true"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M6 18L18 6M6 6l12 12"
+                    />
+                  </svg>
+                </button>
+              </div>
+            )}
             <DndContext
               sensors={sensors}
               collisionDetection={closestCenter}

--- a/src/components/Home/WalletList.tsx
+++ b/src/components/Home/WalletList.tsx
@@ -20,6 +20,7 @@ import {
 import { restrictToVerticalAxis } from '@dnd-kit/modifiers';
 import { CSS } from '@dnd-kit/utilities';
 
+import { useHint } from '../../hooks/useHint';
 import type { Wallet } from '../../types';
 
 interface WalletListProps {
@@ -212,6 +213,8 @@ function WalletListComponent({
   const [editingWalletId, setEditingWalletId] = useState<string | null>(null);
   const [editName, setEditName] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
+  const { visible: reorderHintVisible, dismiss: dismissReorderHint } =
+    useHint('reorder-wallets');
 
   const sensors = useSensors(
     useSensor(MouseSensor, {
@@ -352,6 +355,48 @@ function WalletListComponent({
       onDragEnd={handleDragEnd}
       modifiers={[restrictToVerticalAxis]}
     >
+      {walletsWithId.length >= 2 && reorderHintVisible && (
+        <div className="flex items-center gap-2 px-3 py-2 mb-3 text-xs text-accent bg-accent/5 rounded-lg">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+            className="h-4 w-4 flex-shrink-0"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M12 18v-5.25m0 0a6.01 6.01 0 0 0 1.5-.189m-1.5.189a6.01 6.01 0 0 1-1.5-.189m3.75 7.478a12.06 12.06 0 0 1-4.5 0m3.75 2.383a14.406 14.406 0 0 1-3 0M14.25 18v-.192c0-.983.658-1.823 1.508-2.316a7.5 7.5 0 1 0-7.517 0c.85.493 1.509 1.333 1.509 2.316V18"
+            />
+          </svg>
+          <p className="flex-1">Drag the grip dots to reorder your wallets</p>
+          <button
+            type="button"
+            onClick={dismissReorderHint}
+            className="flex-shrink-0 text-text-muted hover:text-text-primary transition-colors cursor-pointer"
+            aria-label="Dismiss tip"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+              className="h-3.5 w-3.5"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+      )}
       <SortableContext
         items={walletsWithId.map((w) => w.id!)}
         strategy={verticalListSortingStrategy}

--- a/src/hooks/useHint.ts
+++ b/src/hooks/useHint.ts
@@ -1,0 +1,23 @@
+import { useState, useCallback } from 'react';
+
+export function useHint(key: string): { visible: boolean; dismiss: () => void } {
+  const storageKey = `hint-${key}-dismissed`;
+  const [visible, setVisible] = useState<boolean>(() => {
+    try {
+      return !localStorage.getItem(storageKey);
+    } catch {
+      return false;
+    }
+  });
+
+  const dismiss = useCallback((): void => {
+    try {
+      localStorage.setItem(storageKey, '1');
+    } catch {
+      // localStorage unavailable
+    }
+    setVisible(false);
+  }, [storageKey]);
+
+  return { visible, dismiss };
+}


### PR DESCRIPTION
## Summary
Adds two lightweight, one-time contextual hints that teach non-obvious features at the moment they become relevant. Respects the PRD's "no onboarding, no tutorials" principle — these are subtle inline tips, not a tour.

### Reorder hint (Home page)
- Appears above the wallet grid when a user has 2+ wallets
- "Drag the grip dots to reorder your wallets"
- Dismissible, persisted in localStorage, never shown again

### Type toggle hint (Budget detail)
- Appears above the budget table when items exist
- "Tap the colored +/- circle to switch between income and expense"
- Same dismiss/persist pattern

### useHint hook
- New `src/hooks/useHint.ts` — manages one-time hint visibility via localStorage
- Gracefully handles localStorage unavailability (private browsing)

## Changes
- `src/hooks/useHint.ts`: New hook (23 lines)
- `src/components/Home/WalletList.tsx`: Reorder hint banner
- `src/components/Budget/BudgetTable.tsx`: Type toggle hint banner

## Verification
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm test` ✅ (151 tests pass)

Part of #87
