### PR TITLE
design: tokenize semantic status colors — success, error, warning, destructive

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,7 +62,7 @@ export function App(): JSX.Element {
               </>
             ) : (
               <>
-                <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+                <p className="text-sm text-error">{error}</p>
                 <button
                   type="button"
                   onClick={retry}

--- a/src/components/Budget/BudgetRow.tsx
+++ b/src/components/Budget/BudgetRow.tsx
@@ -252,7 +252,7 @@ function BudgetRowComponent({
         <button
           type="button"
           onClick={handleDelete}
-          className="flex h-8 w-8 items-center justify-center rounded-full text-text-muted hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-950 transition-all"
+          className="flex h-8 w-8 items-center justify-center rounded-full text-text-muted hover:text-error hover:bg-error/10 transition-all"
           aria-label="Delete item"
         >
           <svg

--- a/src/components/Budget/BudgetTable.tsx
+++ b/src/components/Budget/BudgetTable.tsx
@@ -405,21 +405,13 @@ export function BudgetTable({
       <div className="fixed bottom-0 left-0 right-0 bg-bg-primary border-t border-border p-3 shadow-lg z-10 safe-area-bottom">
         <div className="max-w-2xl mx-auto flex flex-col sm:flex-row justify-between items-center gap-2 sm:gap-4 text-sm sm:text-base font-bold">
           <div className="flex w-full sm:w-auto justify-between sm:justify-start gap-4">
-            <span className="text-green-600 dark:text-green-400">
-              +{formatAmount(income)}
-            </span>
-            <span className="text-red-600 dark:text-red-400">
-              -{formatAmount(expenses)}
-            </span>
+            <span className="text-success">+{formatAmount(income)}</span>
+            <span className="text-error">-{formatAmount(expenses)}</span>
           </div>
 
           <div className="flex w-full sm:w-auto justify-between sm:justify-end gap-2 border-t sm:border-t-0 border-border pt-2 sm:pt-0">
             <span className="text-text-secondary">Total</span>
-            <span
-              className={
-                balance >= 0 ? 'text-text-primary' : 'text-red-600 dark:text-red-400'
-              }
-            >
+            <span className={balance >= 0 ? 'text-text-primary' : 'text-error'}>
               {balance >= 0 ? '+' : '-'}
               {formatAmount(Math.abs(balance))}
             </span>

--- a/src/components/Home/ConfirmDeleteModal.tsx
+++ b/src/components/Home/ConfirmDeleteModal.tsx
@@ -55,7 +55,7 @@ export function ConfirmDeleteModal({
             type="button"
             onClick={onConfirm}
             disabled={isDeleting}
-            className="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed rounded-lg shadow-sm transition-colors"
+            className="px-4 py-2 text-sm font-medium text-white bg-destructive hover:bg-destructive-hover disabled:opacity-50 disabled:cursor-not-allowed rounded-lg shadow-sm transition-colors"
           >
             {isDeleting ? 'Deleting...' : 'Delete'}
           </button>

--- a/src/components/Home/CreateWalletModal.tsx
+++ b/src/components/Home/CreateWalletModal.tsx
@@ -74,7 +74,7 @@ export function CreateWalletModal({
               // eslint-disable-next-line jsx-a11y/no-autofocus
               autoFocus
             />
-            {error && <p className="mt-2 text-sm text-red-500">{error}</p>}
+            {error && <p className="mt-2 text-sm text-error">{error}</p>}
           </div>
 
           <div className="flex gap-3 justify-end">

--- a/src/components/Home/WalletList.tsx
+++ b/src/components/Home/WalletList.tsx
@@ -127,7 +127,7 @@ function SortableWalletCard({
               onDeleteWallet(wallet);
             }}
             aria-label={`Delete ${wallet.name}`}
-            className="absolute top-2 right-2 p-2 text-text-muted hover:text-red-500 hover:bg-bg-hover rounded-full transition-colors sm:opacity-0 sm:group-hover:opacity-100 focus:opacity-100 z-10"
+            className="absolute top-2 right-2 p-2 text-text-muted hover:text-error hover:bg-bg-hover rounded-full transition-colors sm:opacity-0 sm:group-hover:opacity-100 focus:opacity-100 z-10"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"

--- a/src/components/Layout/SyncIndicator.tsx
+++ b/src/components/Layout/SyncIndicator.tsx
@@ -102,12 +102,10 @@ export function SyncIndicator(): JSX.Element | null {
           />
         )}
 
-        {syncState === 'error' && (
-          <span className="h-2.5 w-2.5 rounded-full bg-red-500" />
-        )}
+        {syncState === 'error' && <span className="h-2.5 w-2.5 rounded-full bg-error" />}
 
         {syncState === 'idle' && pendingCount > 0 && (
-          <span className="h-2.5 w-2.5 rounded-full bg-orange-400" />
+          <span className="h-2.5 w-2.5 rounded-full bg-warning" />
         )}
       </button>
 
@@ -118,9 +116,7 @@ export function SyncIndicator(): JSX.Element | null {
             {formatRelativeSyncTime(lastSyncedAt)}
           </p>
           <p className="mt-1 text-xs text-text-secondary">Pending: {pendingCount}</p>
-          {error && (
-            <p className="mt-1 text-xs text-red-500 dark:text-red-400">{error}</p>
-          )}
+          {error && <p className="mt-1 text-xs text-error">{error}</p>}
         </div>
       )}
     </div>

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -15,6 +15,11 @@
   --color-text-inverse: var(--text-inverse);
   --color-accent: var(--accent);
   --color-border: var(--border);
+  --color-success: var(--success);
+  --color-error: var(--error);
+  --color-warning: var(--warning);
+  --color-destructive: var(--destructive);
+  --color-destructive-hover: var(--destructive-hover);
 }
 
 :root {
@@ -30,6 +35,11 @@
   --text-inverse: #fafaf9;
   --accent: #0f766e;
   --border: #d6d3d1;
+  --success: #16a34a;
+  --error: #dc2626;
+  --warning: #f59e0b;
+  --destructive: #dc2626;
+  --destructive-hover: #b91c1c;
 
   transition:
     background-color 0.2s ease,
@@ -49,4 +59,9 @@
   --text-inverse: rgba(255, 255, 255, 0.87);
   --accent: #2dd4bf;
   --border: #44403c;
+  --success: #4ade80;
+  --error: #f87171;
+  --warning: #fbbf24;
+  --destructive: #dc2626;
+  --destructive-hover: #b91c1c;
 }


### PR DESCRIPTION
## Summary
Adds semantic status color tokens to the design system and replaces hardcoded Tailwind color classes. Eliminates `dark:` duplication — components now use `text-success`, `text-error`, `bg-warning`, `bg-destructive` which auto-switch with the theme.

### New tokens
- `--success` / `text-success` / `bg-success`: Income totals, success indicators
- `--error` / `text-error` / `bg-error`: Expense totals, error text, delete hover
- `--warning` / `bg-warning`: Pending status indicator
- `--destructive` / `bg-destructive`: Delete button background
- `--destructive-hover` / `bg-destructive-hover`: Delete button hover

### What changed
Replaced `text-green-600 dark:text-green-400` → `text-success`, `text-red-600 dark:text-red-400` → `text-error`, etc. across 7 component files.

### What stayed
Toast colors (ToastViewport), auth message colors (AuthPage), and type toggle badge colors (BudgetRow) were left as-is — they're self-contained and use complex multi-property patterns.

## Changes
- `src/styles/theme.css`: 5 new semantic tokens (light + dark) + @theme registrations
- `src/components/Budget/BudgetTable.tsx`: Income/expense/balance text colors
- `src/components/Budget/BudgetRow.tsx`: Delete button hover
- `src/components/Layout/SyncIndicator.tsx`: Status dots + error text
- `src/components/Home/ConfirmDeleteModal.tsx`: Delete button bg
- `src/components/Home/CreateWalletModal.tsx`: Error text
- `src/components/Home/WalletList.tsx`: Delete icon hover
- `src/App.tsx`: Error text

## Verification
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm test` ✅ (151 tests pass)

Part of #87
