### PR TITLE
design: final polish — extend undo window, add reduced motion support

### DIFF
--- a/src/components/Budget/BudgetTable.tsx
+++ b/src/components/Budget/BudgetTable.tsx
@@ -78,7 +78,7 @@ export function BudgetTable({
 
     const timer = setTimeout(() => {
       setDeletedItems([]);
-    }, 5000);
+    }, 8000);
 
     return () => clearTimeout(timer);
   }, [deletedItems]);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -54,3 +54,14 @@ a:not([class]) {
 a:not([class]):hover {
   color: var(--text-primary);
 }
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  ::before,
+  ::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
Final polish pass for the design overhaul epic.

### Undo window extended (5s → 8s)
- Research suggests 8-10 seconds gives users adequate time to notice and react to undo options
- Changed setTimeout in BudgetTable from 5000ms to 8000ms

### Reduced motion support
- Added `@media (prefers-reduced-motion: reduce)` to global.css
- Standard MDN-recommended approach: disables all CSS animations and transitions
- Respects OS accessibility settings (macOS "Reduce motion", Windows "Show animations")

## Changes
- `src/components/Budget/BudgetTable.tsx`: Undo timer 5000 → 8000
- `src/styles/global.css`: prefers-reduced-motion media query

## Verification
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm test` ✅ (151 tests pass)

Part of #87
