### PR TITLE
fix: improve layout hierarchy, touch targets, and action button prominence

### DIFF
--- a/src/components/Budget/BudgetRow.tsx
+++ b/src/components/Budget/BudgetRow.tsx
@@ -150,7 +150,7 @@ function BudgetRowComponent({
     <div
       ref={setNodeRef}
       style={style}
-      className={`flex items-center gap-1 py-1.5 border-b border-border bg-bg-primary ${
+      className={`flex items-center gap-1 py-2.5 border-b border-border bg-bg-primary ${
         item.type === '+' ? 'border-l-4 border-l-income' : 'border-l-4 border-l-expense'
       } ${isDragging ? 'shadow-lg' : ''}`}
       role="row"
@@ -158,7 +158,7 @@ function BudgetRowComponent({
       <div
         {...attributes}
         {...listeners}
-        className="w-8 h-8 flex items-center justify-center cursor-grab active:cursor-grabbing text-text-muted hover:text-text-primary touch-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 focus-visible:outline-none rounded"
+        className="w-10 h-10 flex items-center justify-center cursor-grab active:cursor-grabbing text-text-muted hover:text-text-primary touch-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 focus-visible:outline-none rounded"
         aria-label="Drag to reorder"
       >
         <svg
@@ -197,7 +197,7 @@ function BudgetRowComponent({
       <button
         type="button"
         onClick={toggleType}
-        className={`h-7 w-7 flex items-center justify-center rounded-full text-sm font-semibold transition-colors ${
+        className={`h-9 w-9 flex items-center justify-center rounded-full text-sm font-semibold transition-colors ${
           item.type === '+'
             ? 'bg-income-light text-income'
             : 'bg-expense-light text-expense'
@@ -222,12 +222,12 @@ function BudgetRowComponent({
         />
       </div>
 
-      <div className="flex w-16 items-center justify-end gap-1">
+      <div className="flex w-20 items-center justify-end gap-0.5">
         {onInsertBelow ? (
           <button
             type="button"
             onClick={handleInsertBelow}
-            className="flex h-8 w-8 items-center justify-center rounded-full text-text-secondary hover:bg-accent/10 hover:text-accent transition-all"
+            className="flex h-10 w-10 items-center justify-center rounded-full text-text-secondary hover:bg-accent/10 hover:text-accent transition-all"
             aria-label="Insert item below"
           >
             <svg
@@ -250,7 +250,7 @@ function BudgetRowComponent({
         <button
           type="button"
           onClick={handleDelete}
-          className="flex h-8 w-8 items-center justify-center rounded-full text-text-muted hover:text-error hover:bg-error/10 transition-all"
+          className="flex h-10 w-10 items-center justify-center rounded-full text-text-muted hover:text-error hover:bg-error/10 transition-all"
           aria-label="Delete item"
         >
           <svg

--- a/src/components/Budget/BudgetTable.tsx
+++ b/src/components/Budget/BudgetTable.tsx
@@ -200,12 +200,12 @@ export function BudgetTable({
         <div className="flex-grow overflow-auto pb-20 px-2">
           <div className="flex flex-col">
             <div className="flex px-2 py-1.5 text-xs font-semibold text-text-secondary uppercase tracking-wider border-b border-border">
-              <div className="w-8"></div>
+              <div className="w-10"></div>
               <div className="w-6 text-center flex-shrink-0">#</div>
               <div className="flex-grow pl-2">Name</div>
               <div className="w-8 text-center">Type</div>
               <div className="w-20 sm:w-24 text-right">Amount</div>
-              <div className="w-16"></div>
+              <div className="w-20"></div>
             </div>
             <div className="animate-pulse flex flex-col mt-2">
               <p className="sr-only">Loading budget items...</p>
@@ -214,7 +214,7 @@ export function BudgetTable({
                   key={i}
                   className="flex items-center px-2 py-3 border-b border-border"
                 >
-                  <div className="w-8"></div>
+                  <div className="w-10"></div>
                   <div className="w-6"></div>
                   <div className="flex-grow pl-2">
                     <div className="h-5 bg-bg-secondary rounded w-3/4"></div>
@@ -225,7 +225,7 @@ export function BudgetTable({
                   <div className="w-20 sm:w-24 pl-2">
                     <div className="h-5 bg-bg-secondary rounded w-full"></div>
                   </div>
-                  <div className="w-16"></div>
+                  <div className="w-20"></div>
                 </div>
               ))}
             </div>
@@ -263,12 +263,12 @@ export function BudgetTable({
         ) : (
           <div className="flex flex-col">
             <div className="flex px-2 py-1.5 text-xs font-semibold text-text-secondary uppercase tracking-wider border-b border-border">
-              <div className="w-8"></div>
+              <div className="w-10"></div>
               <div className="w-6 text-center flex-shrink-0">#</div>
               <div className="flex-grow pl-2">Name</div>
               <div className="w-8 text-center">Type</div>
               <div className="w-20 sm:w-24 text-right">Amount</div>
-              <div className="w-16"></div>
+              <div className="w-20"></div>
             </div>
             {items.length > 0 && typeHintVisible && (
               <div className="flex items-center gap-2 px-3 py-2 mb-2 mt-2 text-xs text-accent bg-accent/5 rounded-lg mx-2">

--- a/src/components/Budget/WalletDetailPage.tsx
+++ b/src/components/Budget/WalletDetailPage.tsx
@@ -10,12 +10,11 @@ import { sharePdf } from '../../lib/share';
 
 import { BudgetTable } from './BudgetTable';
 
-const baseActionButtonClassName =
-  'flex items-center justify-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/30 disabled:cursor-not-allowed disabled:opacity-50 cursor-pointer';
+const iconActionButtonClassName =
+  'flex items-center justify-center h-9 w-9 rounded-lg border border-border bg-bg-secondary text-text-secondary hover:border-accent hover:text-accent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/30 disabled:cursor-not-allowed disabled:opacity-50 cursor-pointer';
 
-const secondaryActionButtonClassName = `${baseActionButtonClassName} border border-border bg-bg-secondary text-text-secondary hover:border-accent hover:text-accent`;
-
-const primaryActionButtonClassName = `${baseActionButtonClassName} bg-accent text-white hover:bg-accent/90`;
+const primaryActionButtonClassName =
+  'flex items-center justify-center gap-1.5 rounded-lg px-4 py-2.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/30 disabled:cursor-not-allowed disabled:opacity-50 cursor-pointer bg-accent text-white hover:bg-accent/90';
 
 export function WalletDetailPage(): JSX.Element {
   const { id } = useParams<{ id: string }>();
@@ -60,14 +59,14 @@ export function WalletDetailPage(): JSX.Element {
 
   return (
     <div className="h-full flex flex-col">
-      <div className="flex justify-end gap-2 px-2 pt-1">
+      <div className="flex items-center justify-end gap-2 px-2 pt-2 pb-1">
         <button
           type="button"
           onClick={() => {
             void handleCopy();
           }}
           disabled={!canCopy}
-          className={secondaryActionButtonClassName}
+          className={iconActionButtonClassName}
           aria-label="Copy items"
           title="Copy items"
         >
@@ -86,14 +85,13 @@ export function WalletDetailPage(): JSX.Element {
               d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125H4.125A1.125 1.125 0 0 1 3 20.625V8.625c0-.621.504-1.125 1.125-1.125H7.5m8.25 9.75h4.125c.621 0 1.125-.504 1.125-1.125V4.125A1.125 1.125 0 0 0 19.875 3H9.375C8.754 3 8.25 3.504 8.25 4.125V7.5"
             />
           </svg>
-          <span>Copy</span>
         </button>
         <button
           type="button"
           onClick={() => {
             void handlePaste();
           }}
-          className={secondaryActionButtonClassName}
+          className={iconActionButtonClassName}
           aria-label="Paste items"
           title="Paste items"
         >
@@ -112,7 +110,6 @@ export function WalletDetailPage(): JSX.Element {
               d="M9 5.25h6m-6 3h6m-9 9h12a2.25 2.25 0 0 0 2.25-2.25V5.625A2.625 2.625 0 0 0 17.625 3H15A2.25 2.25 0 0 0 12.75.75h-1.5A2.25 2.25 0 0 0 9 3H6.375A2.625 2.625 0 0 0 3.75 5.625V15A2.25 2.25 0 0 0 6 17.25Z"
             />
           </svg>
-          <span>Paste</span>
         </button>
         <button
           type="button"


### PR DESCRIPTION
## Summary
- **Export PDF promoted**: Now a visually prominent hero action with larger text and padding — unmissable as the app's #2 value prop
- **Copy/Paste demoted**: Icon-only compact buttons (36px squares) — functional but not competing with Export
- **Touch targets increased**: Budget row action buttons from 32px to 40px, type toggle from 28px to 36px — approaching the 44px mobile minimum
- **Row breathing room**: Budget row vertical padding doubled (py-1.5 → py-2.5) — less cramped on mobile

## Testing
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm test` — 151/151 passing ✅
