### PR TITLE
fix: clarify UX copy — fix inaccurate delete warning, rename Trim, add row count

### DIFF
--- a/src/components/Budget/BudgetTable.test.tsx
+++ b/src/components/Budget/BudgetTable.test.tsx
@@ -117,7 +117,7 @@ describe('BudgetTable', () => {
       />
     );
 
-    fireEvent.click(screen.getByText('Add rows'));
+    fireEvent.click(screen.getByText('Add 5 rows'));
     expect(mockAddItems).toHaveBeenCalled();
   });
 

--- a/src/components/Budget/BudgetTable.tsx
+++ b/src/components/Budget/BudgetTable.tsx
@@ -401,7 +401,7 @@ export function BudgetTable({
                 d="M12 4.5v15m7.5-7.5h-15"
               />
             </svg>
-            Add rows
+            Add 5 rows
           </button>
 
           {items.length > 0 &&
@@ -413,7 +413,7 @@ export function BudgetTable({
                 className="px-4 py-2 text-sm font-medium text-text-secondary hover:text-text-primary transition-colors border border-border rounded-lg"
                 title="Remove empty rows from bottom"
               >
-                Trim
+                Remove empty
               </button>
             )}
         </div>

--- a/src/components/Budget/WalletDetailPage.test.tsx
+++ b/src/components/Budget/WalletDetailPage.test.tsx
@@ -114,7 +114,7 @@ describe('WalletDetailPage', () => {
 
     renderWalletPage();
 
-    await user.click(screen.getByRole('button', { name: /copy items/i }));
+    await user.click(screen.getByRole('button', { name: /copy all rows/i }));
 
     expect(setCopiedBudgetItems).toHaveBeenCalledWith({
       sourceWalletId: 'abc123',
@@ -166,7 +166,7 @@ describe('WalletDetailPage', () => {
 
     renderWalletPage();
 
-    await user.click(screen.getByRole('button', { name: /paste items/i }));
+    await user.click(screen.getByRole('button', { name: /paste rows/i }));
 
     expect(getCopiedBudgetItems).toHaveBeenCalledTimes(1);
     expect(mockReadText).not.toHaveBeenCalled();
@@ -199,7 +199,7 @@ describe('WalletDetailPage', () => {
 
     renderWalletPage();
 
-    await user.click(screen.getByRole('button', { name: /paste items/i }));
+    await user.click(screen.getByRole('button', { name: /paste rows/i }));
 
     await waitFor(() => {
       expect(showToast).toHaveBeenCalledWith({

--- a/src/components/Budget/WalletDetailPage.tsx
+++ b/src/components/Budget/WalletDetailPage.tsx
@@ -68,8 +68,8 @@ export function WalletDetailPage(): JSX.Element {
           }}
           disabled={!canCopy}
           className={secondaryActionButtonClassName}
-          aria-label="Copy items"
-          title="Copy items"
+          aria-label="Copy all rows"
+          title="Copy all rows to clipboard"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -94,8 +94,8 @@ export function WalletDetailPage(): JSX.Element {
             void handlePaste();
           }}
           className={secondaryActionButtonClassName}
-          aria-label="Paste items"
-          title="Paste items"
+          aria-label="Paste rows"
+          title="Paste rows from clipboard"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"

--- a/src/components/Home/ConfirmDeleteModal.test.tsx
+++ b/src/components/Home/ConfirmDeleteModal.test.tsx
@@ -17,7 +17,7 @@ describe('ConfirmDeleteModal', () => {
 
     expect(screen.getByText('Delete Test Wallet?')).toBeInTheDocument();
     expect(
-      screen.getByText(/All budget items in this wallet will be lost/)
+      screen.getByText(/All budget items in this wallet will be removed/)
     ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();

--- a/src/components/Home/ConfirmDeleteModal.tsx
+++ b/src/components/Home/ConfirmDeleteModal.tsx
@@ -41,7 +41,8 @@ export function ConfirmDeleteModal({
         </h2>
 
         <p className="text-text-secondary">
-          All budget items in this wallet will be lost. This action cannot be undone.
+          All budget items in this wallet will be removed. You&apos;ll have a few seconds
+          to undo after deleting.
         </p>
 
         <div className="flex gap-3 justify-end pt-2">

--- a/src/components/Home/HomePage.test.tsx
+++ b/src/components/Home/HomePage.test.tsx
@@ -219,7 +219,7 @@ describe('HomePage', () => {
       screen.getByRole('dialog', { name: /delete wallet to delete/i })
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/all budget items in this wallet will be lost/i)
+      screen.getByText(/all budget items in this wallet will be removed/i)
     ).toBeInTheDocument();
 
     // 3. Click delete in the modal


### PR DESCRIPTION
## Summary
- **"Add rows" → "Add 5 rows"**: Users now know exactly how many rows the button creates
- **"Trim" → "Remove empty"**: Label matches tooltip; non-technical users understand it immediately
- **Delete warning fixed**: Old copy said "cannot be undone" — factually wrong since wallet undo was added in #114. New copy: "You'll have a few seconds to undo after deleting."
- **Copy/Paste tooltips clarified**: "Copy items" → "Copy all rows to clipboard", "Paste items" → "Paste rows from clipboard"
- **4 test files updated** to match new copy assertions

## Testing
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm test` — 151/151 passing ✅
