### PR TITLE
feat: add contextual rename hint for wallet cards

### DIFF
--- a/src/components/Home/WalletList.tsx
+++ b/src/components/Home/WalletList.tsx
@@ -213,6 +213,8 @@ function WalletListComponent({
   const [editingWalletId, setEditingWalletId] = useState<string | null>(null);
   const [editName, setEditName] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
+  const { visible: renameHintVisible, dismiss: dismissRenameHint } =
+    useHint('rename-wallet');
   const { visible: reorderHintVisible, dismiss: dismissReorderHint } =
     useHint('reorder-wallets');
 
@@ -355,6 +357,48 @@ function WalletListComponent({
       onDragEnd={handleDragEnd}
       modifiers={[restrictToVerticalAxis]}
     >
+      {walletsWithId.length >= 1 && renameHintVisible && (
+        <div className="flex items-center gap-2 px-3 py-2 mb-3 text-xs text-accent bg-accent/5 rounded-lg">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+            className="h-4 w-4 flex-shrink-0"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M12 18v-5.25m0 0a6.01 6.01 0 0 0 1.5-.189m-1.5.189a6.01 6.01 0 0 1-1.5-.189m3.75 7.478a12.06 12.06 0 0 1-4.5 0m3.75 2.383a14.406 14.406 0 0 1-3 0M14.25 18v-.192c0-.983.658-1.823 1.508-2.316a7.5 7.5 0 1 0-7.517 0c.85.493 1.509 1.333 1.509 2.316V18"
+            />
+          </svg>
+          <p className="flex-1">Tap the pencil icon on any wallet to rename it</p>
+          <button
+            type="button"
+            onClick={dismissRenameHint}
+            className="flex-shrink-0 text-text-muted hover:text-text-primary transition-colors cursor-pointer"
+            aria-label="Dismiss tip"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+              className="h-3.5 w-3.5"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+      )}
       {walletsWithId.length >= 2 && reorderHintVisible && (
         <div className="flex items-center gap-2 px-3 py-2 mb-3 text-xs text-accent bg-accent/5 rounded-lg">
           <svg


### PR DESCRIPTION
## Summary
- Add one-time contextual hint: "Tap the pencil icon on any wallet to rename it"
- Shows when user has 1+ wallets, dismissible via X (stored in localStorage)
- Uses the same `useHint` + lightbulb icon pattern as the existing reorder and type-toggle hints
- Addresses critique finding: the 14px pencil icon on wallet cards is easy to miss for first-time users

## Testing
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm test` — 151/151 passing ✅
