### PR TITLE
fix: add dismiss button to install prompt with 30-day cooldown

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,13 @@ import { SyncProvider } from './hooks/useSync';
 import './components/Layout/pwaPrompts.css';
 
 export function App(): JSX.Element {
-  const { isInstallable, isInstalled, promptInstall } = useInstallPrompt();
+  const {
+    isInstallable,
+    isInstalled,
+    isDismissed,
+    promptInstall,
+    dismiss: dismissInstall,
+  } = useInstallPrompt();
   const { shouldShow: showIOSPrompt, dismiss: dismissIOSPrompt } = useIOSInstallPrompt();
   const { offlineReady, needRefresh, updateServiceWorker, dismiss } =
     usePwaUpdatePrompt();
@@ -33,7 +39,9 @@ export function App(): JSX.Element {
       <InstallPrompt
         isInstallable={isInstallable}
         isInstalled={isInstalled}
+        isDismissed={isDismissed}
         onInstall={promptInstall}
+        onDismiss={dismissInstall}
       />
       <IOSInstallPrompt shouldShow={showIOSPrompt} onDismiss={dismissIOSPrompt} />
       <Routes>

--- a/src/components/Layout/InstallPrompt.test.tsx
+++ b/src/components/Layout/InstallPrompt.test.tsx
@@ -3,27 +3,29 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { InstallPrompt } from './InstallPrompt';
 
+const defaultProps = {
+  isInstallable: true,
+  isInstalled: false,
+  isDismissed: false,
+  onInstall: vi.fn().mockResolvedValue(undefined),
+  onDismiss: vi.fn(),
+};
+
 describe('InstallPrompt', () => {
   it('does not render when app is not installable', () => {
-    render(
-      <InstallPrompt
-        isInstallable={false}
-        isInstalled={false}
-        onInstall={vi.fn().mockResolvedValue(undefined)}
-      />
-    );
+    render(<InstallPrompt {...defaultProps} isInstallable={false} />);
 
     expect(screen.queryByRole('button', { name: 'Install app' })).not.toBeInTheDocument();
   });
 
   it('does not render when app is already installed', () => {
-    render(
-      <InstallPrompt
-        isInstallable={true}
-        isInstalled={true}
-        onInstall={vi.fn().mockResolvedValue(undefined)}
-      />
-    );
+    render(<InstallPrompt {...defaultProps} isInstalled={true} />);
+
+    expect(screen.queryByRole('button', { name: 'Install app' })).not.toBeInTheDocument();
+  });
+
+  it('does not render when dismissed', () => {
+    render(<InstallPrompt {...defaultProps} isDismissed={true} />);
 
     expect(screen.queryByRole('button', { name: 'Install app' })).not.toBeInTheDocument();
   });
@@ -31,12 +33,20 @@ describe('InstallPrompt', () => {
   it('renders and calls install handler', () => {
     const onInstall = vi.fn().mockResolvedValue(undefined);
 
-    render(
-      <InstallPrompt isInstallable={true} isInstalled={false} onInstall={onInstall} />
-    );
+    render(<InstallPrompt {...defaultProps} onInstall={onInstall} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Install app' }));
 
     expect(onInstall).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onDismiss when dismiss button is clicked', () => {
+    const onDismiss = vi.fn();
+
+    render(<InstallPrompt {...defaultProps} onDismiss={onDismiss} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/Layout/InstallPrompt.tsx
+++ b/src/components/Layout/InstallPrompt.tsx
@@ -1,15 +1,19 @@
 interface InstallPromptProps {
   isInstallable: boolean;
   isInstalled: boolean;
+  isDismissed: boolean;
   onInstall: () => Promise<void>;
+  onDismiss: () => void;
 }
 
 export function InstallPrompt({
   isInstallable,
   isInstalled,
+  isDismissed,
   onInstall,
+  onDismiss,
 }: InstallPromptProps): JSX.Element | null {
-  if (isInstalled || !isInstallable) {
+  if (isInstalled || !isInstallable || isDismissed) {
     return null;
   }
 
@@ -28,6 +32,13 @@ export function InstallPrompt({
           onClick={() => void onInstall()}
         >
           Install app
+        </button>
+        <button
+          type="button"
+          className="pwa-prompt__action-secondary"
+          onClick={onDismiss}
+        >
+          Dismiss
         </button>
       </div>
     </div>

--- a/src/hooks/useInstallPrompt.ts
+++ b/src/hooks/useInstallPrompt.ts
@@ -13,7 +13,19 @@ export interface DeferredInstallPromptEvent extends Event {
 interface UseInstallPromptResult {
   isInstallable: boolean;
   isInstalled: boolean;
+  isDismissed: boolean;
   promptInstall: () => Promise<void>;
+  dismiss: () => void;
+}
+
+const INSTALL_PROMPT_DISMISS_KEY = 'install-prompt-dismissed';
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+
+function isDismissedInStorage(): boolean {
+  const dismissedAt = localStorage.getItem(INSTALL_PROMPT_DISMISS_KEY);
+  if (!dismissedAt) return false;
+  const dismissedTime = parseInt(dismissedAt, 10);
+  return Date.now() - dismissedTime < THIRTY_DAYS_MS;
 }
 
 function isDeferredInstallPromptEvent(event: Event): event is DeferredInstallPromptEvent {
@@ -25,6 +37,7 @@ export function useInstallPrompt(): UseInstallPromptResult {
     null
   );
   const [isInstalled, setIsInstalled] = useState(false);
+  const [isDismissed, setIsDismissed] = useState(() => isDismissedInStorage());
 
   useEffect(() => {
     const handleBeforeInstallPrompt = (event: Event): void => {
@@ -67,9 +80,16 @@ export function useInstallPrompt(): UseInstallPromptResult {
     }
   }, [deferredPrompt]);
 
+  const dismiss = useCallback((): void => {
+    localStorage.setItem(INSTALL_PROMPT_DISMISS_KEY, Date.now().toString());
+    setIsDismissed(true);
+  }, []);
+
   return {
     isInstallable: deferredPrompt !== null,
     isInstalled,
+    isDismissed,
     promptInstall,
+    dismiss,
   };
 }


### PR DESCRIPTION
## Summary
- Add a "Dismiss" button to the PWA install prompt (desktop/Android) so users can close it
- Dismissal persists in localStorage with a 30-day cooldown before re-showing
- Mirrors the existing pattern from `useIOSInstallPrompt` and `ReloadPrompt`

## What changed
- **`useInstallPrompt.ts`** — Added `isDismissed` state (initialized from localStorage), `dismiss()` callback with 30-day cooldown via `install-prompt-dismissed` key
- **`InstallPrompt.tsx`** — Added `isDismissed` + `onDismiss` props, renders null when dismissed, added "Dismiss" button using existing `pwa-prompt__action-secondary` class
- **`App.tsx`** — Wired new `isDismissed` and `dismiss` from hook to component
- **`InstallPrompt.test.tsx`** — Added tests for dismiss visibility and click handler, updated existing tests with new required props

## Testing
- `npm run lint && npm run typecheck && npm test` — all 152 tests pass, zero warnings
